### PR TITLE
Set devEngines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: Test & Deploy
 
-env:
-  PROTO_TELEMETRY: false
-
 on:
   push:
     branches: [main]
@@ -23,10 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: moonrepo/setup-toolchain@v0
-        with:
-          auto-install: true
+      - uses: jdx/mise-action@v4
 
       - run: npm it
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Test & Deploy
 
+env:
+  PROTO_TELEMETRY: false
+
 on:
   push:
     branches: [main]
@@ -21,10 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: moonrepo/setup-toolchain@v0
         with:
-          node-version: 25
-          cache: npm
+          auto-install: true
 
       - run: npm it
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - run: npm it
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,3 @@
-[tools]
-node = "25.9.0"
-npm = "11.14.1"
-
 [tasks.install]
 run = "npm i"
 alias = "i"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [settings]
-idiomatic_version_file_enable_tools = ["node"]
+idiomatic_version_file_enable_tools = ["node", "npm"]
 
 [tasks.install]
 run = "npm i"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,6 @@
+[settings]
+idiomatic_version_file_enable_tools = ["node"]
+
 [tasks.install]
 run = "npm i"
 alias = "i"

--- a/package.json
+++ b/package.json
@@ -17,5 +17,15 @@
     "esbuild": "^0.28.0",
     "lightningcss": "^1.30.0",
     "postcss": "^8.5.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "25.9.0"
+    },
+    "packageManager": {
+      "name": "npm",
+      "version": "11.14.1"
+    }
   }
 }


### PR DESCRIPTION
`devEngines` is an official part of the `package.json` [specification](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines).

It communicates the version of Node and npm to use during development. Tools like Mise and Proto should already support this spec and use it as a source for the Node/npm versions to download/install.

You can keep the versions in the `.mise.toml` too, if you want, but it will introduce the possibility of the version getting out-of-sync, since there would be two sources of truth.

Since this is the official specification, all version management tools should adopt it, and it should work for all contributors, no matter what tooling they use.