### PR TITLE
Site styling improvements

### DIFF
--- a/style.css
+++ b/style.css
@@ -218,6 +218,11 @@ details iframe {
 .detail-outputs {
   display: grid;
   gap: 0.5rem;
+  font-size: 0.7rem;
+  h4 {
+    display: flex;
+    gap: 4px;
+  }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
With "Sass" added, there is less room overall, causing some of the content to be squished.

* Reduces font-size of the code snippet
* Prevents the icon next to the minifier name from overflowing to a new line

<img width="1948" height="871" alt="Before and After animation of visual changes" src="https://github.com/user-attachments/assets/00dd84ef-0637-42ac-956d-251077cd6c41" />

Long term some overflow scrollbars would be better, to support more minifiers, but this is a simple fix for now.