### PR TITLE
Fix duplicate "container" test

### DIFF
--- a/results-history.json
+++ b/results-history.json
@@ -1,5 +1,46 @@
 [
   {
+    "date": "2026-05-13T23:07:27.010Z",
+    "testCount": 398,
+    "minifiers": {
+      "clean-css": {
+        "version": "5.3.3",
+        "pass": 149,
+        "total": 398
+      },
+      "csskit": {
+        "version": "0.0.21",
+        "pass": 142,
+        "total": 398
+      },
+      "cssnano": {
+        "version": "8.0.1",
+        "pass": 207,
+        "total": 398
+      },
+      "csso": {
+        "version": "5.0.5",
+        "pass": 148,
+        "total": 398
+      },
+      "esbuild": {
+        "version": "0.28.0",
+        "pass": 182,
+        "total": 398
+      },
+      "lightningcss": {
+        "version": "1.32.0",
+        "pass": 273,
+        "total": 398
+      },
+      "sass": {
+        "version": "1.99.0",
+        "pass": 119,
+        "total": 398
+      }
+    }
+  },
+  {
     "date": "2026-05-13T11:36:50.953Z",
     "testCount": 398,
     "minifiers": {

--- a/tests/container/0001/expected.css
+++ b/tests/container/0001/expected.css
@@ -1,1 +1,1 @@
-@container sidebar (min-width:700px){a{color:red}}
+@container sidebar (width>700px){a{color:red}}

--- a/tests/container/0001/source.css
+++ b/tests/container/0001/source.css
@@ -1,4 +1,4 @@
-@container sidebar (min-width: 700px) {
+@container sidebar (width > 700px) {
   a {
     color: red;
   }


### PR DESCRIPTION
These two tests have identical inputs:

* `tests/container/0001/source.css`
* `tests/container/0006/source.css`

But their outputs are different. Making it impossible for a minifier to pass both tests. The obvious solution would be to delete the test with a larger output (`expected.css`). However, when looking at the `README.md` of each, their intent is to test different things.

I could update 0001 it to have the same output as 0006.

```diff
-@container sidebar (min-width:700px){a{color:red}}
+@container sidebar (width>=700px){a{color:red}}
```

But then it would be testing more than the README's intent, and duplicating the efforts of 0006.

I changed the source to remove the need for the width transformation required in 0006. We are not testing the conversion from `min-width` to `width>=`. We are just focusing on the removing and keeping of specific whitespace. Then 0006 can focus on the width transformation.

As a result of this change:

* `clean-css` went from 150 passing down to 149 passing.
* `lightningcss` went from 272 passing up to 273 passing.