### PR TITLE
Escaping HREF attributes

### DIFF
--- a/results.json
+++ b/results.json
@@ -1034,6 +1034,15 @@
     "lightningcss": true,
     "sass": false
   },
+  "escaping/0013": {
+    "clean-css": false,
+    "csskit": false,
+    "cssnano": false,
+    "csso": false,
+    "esbuild": false,
+    "lightningcss": true,
+    "sass": false
+  },
   "font-face/0001": {
     "clean-css": true,
     "csskit": true,

--- a/tests/escaping/0013/README.md
+++ b/tests/escaping/0013/README.md
@@ -1,0 +1,8 @@
+# Escaping HREF attribute values
+
+Attribute selectors can include values in optional quotes. Since HREF
+specifically deals with URL paths, they will naturally contain characters that
+need escaped if not wrapped in quotes (`#`, `.`, `:`, etc). A minifier should
+remove the quotes and favor escaping if the total characters in the escaped
+version is fewer than if it was kept in quotes. It should remove escapes and
+prefer quotes when that has fewer characters.

--- a/tests/escaping/0013/expected.css
+++ b/tests/escaping/0013/expected.css
@@ -1,1 +1,1 @@
-[href=\#],[href=\/],[href=file\.html],[href=example\.com],[href="https://example.com"]{color:red}
+[href=\#],[href=\/],[href=file\.html],[href="https://example.com"]{color:red}

--- a/tests/escaping/0013/expected.css
+++ b/tests/escaping/0013/expected.css
@@ -1,0 +1,1 @@
+[href=\#],[href=\/],[href=file\.html],[href=example\.com],[href="https://example.com"]{color:red}

--- a/tests/escaping/0013/source.css
+++ b/tests/escaping/0013/source.css
@@ -1,0 +1,7 @@
+[href="#"],
+[href="/"],
+[href="file.html"],
+[href="example.com"],
+[href=https\:\/\/example\.com] {
+  color: red;
+}

--- a/tests/escaping/0013/source.css
+++ b/tests/escaping/0013/source.css
@@ -1,7 +1,6 @@
 [href="#"],
 [href="/"],
 [href="file.html"],
-[href="example.com"],
 [href=https\:\/\/example\.com] {
   color: red;
 }

--- a/tests/escaping/0013/validate.html
+++ b/tests/escaping/0013/validate.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="../../../validate.css">
+    <title>Validate: Escaping HREF attribute values</title>
+  </head>
+  <body>
+    <div class="compare">
+      <div>
+        <h2>Source (unminified)</h2>
+        <style>
+          .source {
+            [href="#"],
+            [href="/"],
+            [href="file.html"],
+            [href="example.com"],
+            [href=https\:\/\/example\.com] {
+              color: red;
+            }
+          }
+        </style>
+        <div class="source">
+          <a href="#">octothorpe</a>
+          <a href="/">root slash</a>
+          <a href="file.html">file</a>
+          <a href="https://example.com">long url</a>
+          <a href="example.com">short url</a>
+        </div>
+      </div>
+      <div>
+        <h2>Expected (minified)</h2>
+        <style>
+          .expected{[href=\#],[href=\/],[href=file\.html],[href=example\.com],[href="https://example.com"]{color:red}}
+        </style>
+        <div class="expected">
+          <a href="#">octothorpe</a>
+          <a href="/">root slash</a>
+          <a href="file.html">file</a>
+          <a href="https://example.com">long url</a>
+          <a href="example.com">short url</a>
+        </div>
+      </div>
+    </div>
+    <p>
+      All above examples should have red text. If they differ, the
+      minification is invalid.
+    </p>
+  </body>
+</html>

--- a/tests/escaping/0013/validate.html
+++ b/tests/escaping/0013/validate.html
@@ -14,7 +14,6 @@
             [href="#"],
             [href="/"],
             [href="file.html"],
-            [href="example.com"],
             [href=https\:\/\/example\.com] {
               color: red;
             }
@@ -24,21 +23,19 @@
           <a href="#">octothorpe</a>
           <a href="/">root slash</a>
           <a href="file.html">file</a>
-          <a href="https://example.com">long url</a>
-          <a href="example.com">short url</a>
+          <a href="https://example.com">url</a>
         </div>
       </div>
       <div>
         <h2>Expected (minified)</h2>
         <style>
-          .expected{[href=\#],[href=\/],[href=file\.html],[href=example\.com],[href="https://example.com"]{color:red}}
+          .expected{[href=\#],[href=\/],[href=file\.html],[href="https://example.com"]{color:red}}
         </style>
         <div class="expected">
           <a href="#">octothorpe</a>
           <a href="/">root slash</a>
           <a href="file.html">file</a>
-          <a href="https://example.com">long url</a>
-          <a href="example.com">short url</a>
+          <a href="https://example.com">url</a>
         </div>
       </div>
     </div>

--- a/tests/selectors-advanced/0010/expected.css
+++ b/tests/selectors-advanced/0010/expected.css
@@ -1,1 +1,1 @@
-a:visited,area:visited,link:visited,.foo:not(:link),h1:not(:link),[href]:not(:link),[href="#"]:not(:link),a[href]:visited,area[href="#"]:visited,:where(:not(:link)),a:where(:visited){color:red}
+a:visited,area:visited,link:visited,.foo:not(:link),h1:not(:link),[href]:not(:link),[href="/foo.html#bar"]:not(:link),a[href]:visited,area[href="/foo.html#bar"]:visited,:where(:not(:link)),a:where(:visited){color:red}

--- a/tests/selectors-advanced/0010/source.css
+++ b/tests/selectors-advanced/0010/source.css
@@ -4,9 +4,9 @@ link:not(:link),
 .foo:not(:link),
 h1:not(:link),
 [href]:not(:link),
-[href="#"]:not(:link),
+[href="/foo.html#bar"]:not(:link),
 a[href]:not(:link),
-area[href="#"]:not(:link),
+area[href="/foo.html#bar"]:not(:link),
 :where(:not(:link)),
 a:where(:not(:link)) {
   color: red;


### PR DESCRIPTION
Found this when looking at the `selectors-advanced/0010` test that just went in. It contains:

```css
area[href="#"]
```

Wait a second, quotes are optional in attributes without spaces

```css
area[href=#]
```

But a `#` is a special character used in CSS selectors to indicate IDs, so it needs escaped:

```css
area[href=\#]
```

It still works as the same selector, but it is now shorter.

So I updated that test, and added a new test that is specific to this.

LightningCSS passes this new test, the rest fail.