### PR TITLE
Fix offset in test CLI report

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -196,7 +196,13 @@ for (const minifierName of minifiers) {
 console.log("\nCSS Minify Tests\n");
 
 const colWidth = 14;
-const testColWidth = 16;
+let testColWidth = 0;
+for (const group of sortedGroups) {
+  if (testColWidth < group.name.length) {
+    testColWidth = group.name.length;
+  }
+}
+
 
 function pad(str, width) {
   return String(str).padEnd(width);


### PR DESCRIPTION
This has been bugging me since the first time I ran `npm t`.

<img width="1796" height="1134" alt="selectors-advanced-offset-bug" src="https://github.com/user-attachments/assets/cc86a7ef-4369-42ca-a792-6281842bfa31" />
