### PR TITLE
Code organization: Loaders folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,16 +165,16 @@ If the minifier is a CLI binary rather than a JS API, see
 
 ### 3. Register the adapter
 
-In `lib/minify.js`:
+In `lib/loaders/loadAllMinifiers.js`:
 
 1. Import the adapter at the top of the file.
 2. Add an entry to the `registry` Map. The key is the npm package name (used
    for version lookups and display).
 
 ```js
-import myMinifier from "./minifiers/my-minifier.js";
+import myMinifier from "../minifiers/my-minifier.js";
 
-const registry = new Map([
+export const registry = new Map([
   // ... existing entries ...
   ["my-minifier", myMinifier],
 ]);

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Want to add your minifier to the suite? See the
 2. Register it in `lib/minify.js`.
 3. Add the npm package to `devDependencies`.
 4. Run `npm test` and open a PR.
+5. Update the README to add it to the list of "Tested minifiers"
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Want to add your minifier to the suite? See the
 
 1. Create an adapter in `lib/minifiers/<name>.js` that exports a default
    `minify(source)` function returning the minified CSS string.
-2. Register it in `lib/minify.js`.
+2. Register it in `‎lib/loaders/loadAllMinifiers.js`.
 3. Add the npm package to `devDependencies`.
 4. Run `npm test` and open a PR.
 5. Update the README to add it to the list of "Tested minifiers"

--- a/lib/createWebsite/makeRealWorldTable.js
+++ b/lib/createWebsite/makeRealWorldTable.js
@@ -3,8 +3,9 @@ import { join } from 'node:path';
 
 import prettyMilliseconds from 'pretty-ms';
 
+import { minifiers } from '../loaders/loadAllMinifiers.js';
 import { loadAllRealWorldTests } from '../loaders/loadAllRealWorldTests.js';
-import { minifiers, minify } from '../minify.js';
+import { minify } from '../minify.js';
 
 const __dirname = import.meta.dirname;
 const ERROR = 'ERROR';

--- a/lib/createWebsite/makeRealWorldTable.js
+++ b/lib/createWebsite/makeRealWorldTable.js
@@ -2,8 +2,8 @@ import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import prettyMilliseconds from 'pretty-ms';
-import getRealWorldCSS from 'real-world-css-libraries';
 
+import { loadAllRealWorldTests } from '../loaders/loadAllRealWorldTests.js';
 import { minifiers, minify } from '../minify.js';
 
 const __dirname = import.meta.dirname;
@@ -11,34 +11,7 @@ const ERROR = 'ERROR';
 
 const minifyAllRealWorldTests = async function () {
   const startAll = Date.now();
-  let libraries = [];
-  try {
-    libraries = getRealWorldCSS();
-  } catch (error) {
-    console.log('Failed to read the CSS files.');
-    console.log(error);
-  }
-
-  libraries = libraries.filter((library) => {
-    // At this size limit these tests take around a minute,
-    // without this they take hours.
-    const fileIsReasonablySized = library.size < 500_000;
-
-    const knownBads = [
-      // Sass warns about deprecated @moz-document
-      'GitHub-Windows',
-      // Sass complains about incorrect hsla() syntax
-      'Halfmoon',
-      // Sass warns about deprecated darken()
-      'Jupyter Themes'
-    ];
-    const fileIsKnownBad = knownBads.includes(library.name);
-
-    return (
-      fileIsReasonablySized &&
-      !fileIsKnownBad
-    );
-  });
+  const libraries = loadAllRealWorldTests();
 
   for (const minifier of minifiers) {
     for (const library of libraries) {

--- a/lib/loaders/loadAllMinifiers.js
+++ b/lib/loaders/loadAllMinifiers.js
@@ -1,0 +1,37 @@
+/**
+ * @file Loads in all of the minification functions into a Map to allow looping
+ *       over them in tests.
+ */
+
+import cleanCss from "../minifiers/clean-css.js";
+import csslop from "../minifiers/csslop.js";
+import csskit from "../minifiers/csskit.js";
+import cssnano from "../minifiers/cssnano.js";
+import csso from "../minifiers/csso.js";
+import esbuild from "../minifiers/esbuild.js";
+import lightningcss from "../minifiers/lightningcss.js";
+import sass from "../minifiers/sass.js";
+
+/**
+ * The key is the npm package name, used for version lookups and displaying in
+ * reports.
+ *
+ * @type {Map}
+ */
+export const registry = new Map([
+  ["clean-css", cleanCss],
+  ["csskit", csskit],
+  ["csslop", csslop],
+  ["cssnano", cssnano],
+  ["csso", csso],
+  ["esbuild", esbuild],
+  ["lightningcss", lightningcss],
+  ["sass", sass],
+]);
+
+/**
+ * Names of all the minifier tools.
+ *
+ * @type {string[]}  ['clean-css', 'csskit', ...]
+ */
+export const minifiers = [...registry.keys()];

--- a/lib/loaders/loadAllRealWorldTests.js
+++ b/lib/loaders/loadAllRealWorldTests.js
@@ -1,0 +1,67 @@
+/**
+ * @file Loads in a list of real-world CSS files to be minified.
+ */
+
+import getRealWorldCSS from 'real-world-css-libraries';
+
+/**
+ * @typedef  {Object} REALLIBRARY
+ * @property {string} fileName    The original filename, can be used as a unique ID
+ * @property {string} name        Presentation-ready name, with spaces and capitals
+ * @property {string} version     The version of the file, starting with 'v'
+ * @property {string} license     Shortform Open Source license name used by the library
+ * @property {string} source      The entire CSS file's contents as a string
+ * @property {number} size        The filesize on disk, different than source.length
+ * @property {string} url         The URL for where the file originated
+ *
+ * @example
+ * {
+ *   fileName: '960.gs-v0.0.0.css',
+ *   name: '960.gs',
+ *   version: 'v1.0.0',
+ *   license: 'GPL-3.0 or MIT',
+ *   source: '/*\n  960 Grid System ~ Core CSS.\n  Learn more ~ http://9...',
+ *   size: 9989,
+ *   url: 'https://github.com/nathansmith/960-Grid-System/blob/master/code/css/960.css'
+ * }
+ */
+
+/**
+ * Uses the real-world-css-libraries library to load in a 3rd-party list of
+ * open source CSS files, along with meta-data about the files. Also filters
+ * out CSS files that are known to have issues in this repo.
+ *
+ * @return {REALLIBRARY[]} Array of objects with information on each CSS file
+ */
+export const loadAllRealWorldTests = function () {
+  let libraries = [];
+  try {
+    libraries = getRealWorldCSS();
+  } catch (error) {
+    console.log('Failed to read real-world CSS files.');
+    console.log(error);
+  }
+
+  libraries = libraries.filter((library) => {
+    // At this size limit these tests take around a minute,
+    // without this they take hours.
+    const fileIsReasonablySized = library.size < 500_000;
+
+    const knownBads = [
+      // Sass warns about deprecated @moz-document
+      'GitHub-Windows',
+      // Sass complains about incorrect hsla() syntax
+      'Halfmoon',
+      // Sass warns about deprecated darken()
+      'Jupyter Themes'
+    ];
+    const fileIsKnownBad = knownBads.includes(library.name);
+
+    return (
+      fileIsReasonablySized &&
+      !fileIsKnownBad
+    );
+  });
+
+  return libraries;
+};

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -1,26 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import cleanCss from "./minifiers/clean-css.js";
-import csslop from "./minifiers/csslop.js";
-import csskit from "./minifiers/csskit.js";
-import cssnano from "./minifiers/cssnano.js";
-import csso from "./minifiers/csso.js";
-import esbuild from "./minifiers/esbuild.js";
-import lightningcss from "./minifiers/lightningcss.js";
-import sass from "./minifiers/sass.js";
 
-const registry = new Map([
-  ["clean-css", cleanCss],
-  ["csskit", csskit],
-  ["csslop", csslop],
-  ["cssnano", cssnano],
-  ["csso", csso],
-  ["esbuild", esbuild],
-  ["lightningcss", lightningcss],
-  ["sass", sass],
-]);
-
-export const minifiers = [...registry.keys()];
+import { minifiers, registry } from "./loaders/loadAllMinifiers.js";
 
 export async function minify(name, source) {
   const fn = registry.get(name);

--- a/run-tests.js
+++ b/run-tests.js
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { minify, minifiers, getVersions } from "./lib/minify.js";
+import { minifiers } from './lib/loaders/loadAllMinifiers.js';
+import { minify, getVersions } from "./lib/minify.js";
 import { resultsAsHTML } from "./lib/results-as-html.js";
 import { appendHistory } from "./lib/history.js";
 import { traverseDir } from "./lib/traverse-dir.js";

--- a/run-tests.js
+++ b/run-tests.js
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { minifiers } from './lib/loaders/loadAllMinifiers.js';
+import { minifiers } from "./lib/loaders/loadAllMinifiers.js";
 import { minify, getVersions } from "./lib/minify.js";
 import { resultsAsHTML } from "./lib/results-as-html.js";
 import { appendHistory } from "./lib/history.js";


### PR DESCRIPTION
Code organization refactor:

* Creates a `/lib/loaders` folder
* Moves the loading of Minifier functions to its own file
* Moves the loading of Real-World CSS files to its own file
* Updates all references to point to these new locations
* Updates documentation to match new locations

There will be one follow up to this that will be split off to a separate PR because it is a more complex refactor:

* Move the loading of test files into it's own file. Currently the loading of tests from the file system and minifying of them are happening in the same loop. Since this would require decoupling of these tasks, it will be done in its own PR.
  * The benefit will be better organized, simpler, and more focused code.
  * It also opens up the potential opportunity to do benchmarks of the minifiers across the 412 tests. Since the minification process would no longer include the slow and unrelated step of reading files from disk. Making the benchmarks accurate and focused. (if desired)