### PR TITLE
Dependencies, NO_COLOR, trim output

### DIFF
--- a/data/real-world-results.json
+++ b/data/real-world-results.json
@@ -5,11 +5,11 @@
     "size": 13747,
     "results": {
       "clean-css": 10141,
-      "csskit": 10047,
+      "csskit": 10046,
       "csslop": 9381,
       "cssnano": 10083,
       "csso": 10192,
-      "esbuild": 10060,
+      "esbuild": 10059,
       "lightningcss": 10004,
       "sass": 10398
     }
@@ -20,11 +20,11 @@
     "size": 9989,
     "results": {
       "clean-css": 5772,
-      "csskit": 5641,
+      "csskit": 5640,
       "csslop": 5772,
       "cssnano": 5772,
       "csso": 5768,
-      "esbuild": 5773,
+      "esbuild": 5772,
       "lightningcss": 5772,
       "sass": 5772
     }
@@ -35,11 +35,11 @@
     "size": 23150,
     "results": {
       "clean-css": 19136,
-      "csskit": 19581,
+      "csskit": 19580,
       "csslop": 17654,
       "cssnano": 19105,
       "csso": 19073,
-      "esbuild": 19251,
+      "esbuild": 19250,
       "lightningcss": "ERROR",
       "sass": "ERROR"
     }
@@ -50,13 +50,13 @@
     "size": 9256,
     "results": {
       "clean-css": 7225,
-      "csskit": 6659,
+      "csskit": 6658,
       "csslop": 6611,
       "cssnano": 7215,
       "csso": 6631,
-      "esbuild": 7216,
+      "esbuild": 7215,
       "lightningcss": 6627,
-      "sass": 6665
+      "sass": 6664
     }
   },
   {
@@ -65,13 +65,13 @@
     "size": 409926,
     "results": {
       "clean-css": 315879,
-      "csskit": 336987,
+      "csskit": 336986,
       "csslop": 324108,
       "cssnano": 311452,
       "csso": 315667,
-      "esbuild": 320008,
+      "esbuild": 320007,
       "lightningcss": 313923,
-      "sass": 343910
+      "sass": 343909
     }
   },
   {
@@ -80,11 +80,11 @@
     "size": 95377,
     "results": {
       "clean-css": 74512,
-      "csskit": 74390,
+      "csskit": 74389,
       "csslop": 36221,
       "cssnano": 71725,
       "csso": 73222,
-      "esbuild": 73462,
+      "esbuild": 73461,
       "lightningcss": 23943,
       "sass": 77691
     }
@@ -95,11 +95,11 @@
     "size": 67468,
     "results": {
       "clean-css": 50273,
-      "csskit": 50649,
+      "csskit": 50648,
       "csslop": 17396,
       "cssnano": 50178,
       "csso": 49294,
-      "esbuild": 50201,
+      "esbuild": 50200,
       "lightningcss": 41118,
       "sass": 50896
     }
@@ -110,11 +110,11 @@
     "size": 38452,
     "results": {
       "clean-css": 28360,
-      "csskit": 28185,
+      "csskit": 28184,
       "csslop": 14423,
       "cssnano": 28178,
       "csso": 27879,
-      "esbuild": 28155,
+      "esbuild": 28154,
       "lightningcss": 10128,
       "sass": 28566
     }
@@ -125,13 +125,13 @@
     "size": 9073,
     "results": {
       "clean-css": 7786,
-      "csskit": 7938,
+      "csskit": 7937,
       "csslop": 7379,
       "cssnano": 7558,
       "csso": 7544,
-      "esbuild": 7713,
+      "esbuild": 7712,
       "lightningcss": 7426,
-      "sass": 7814
+      "sass": 7813
     }
   },
   {
@@ -140,11 +140,11 @@
     "size": 7577,
     "results": {
       "clean-css": 6556,
-      "csskit": 6696,
+      "csskit": 6695,
       "csslop": 6456,
       "cssnano": 6476,
       "csso": 6516,
-      "esbuild": 6602,
+      "esbuild": 6601,
       "lightningcss": 6489,
       "sass": 6650
     }
@@ -155,11 +155,11 @@
     "size": 47232,
     "results": {
       "clean-css": 15772,
-      "csskit": 15941,
+      "csskit": 15940,
       "csslop": 15689,
       "cssnano": 43633,
       "csso": 15526,
-      "esbuild": 15886,
+      "esbuild": 15885,
       "lightningcss": 15832,
       "sass": 16429
     }
@@ -170,11 +170,11 @@
     "size": 107060,
     "results": {
       "clean-css": 88176,
-      "csskit": 89187,
+      "csskit": 89186,
       "csslop": 85341,
       "cssnano": 87684,
       "csso": 87717,
-      "esbuild": 88572,
+      "esbuild": 88571,
       "lightningcss": 88073,
       "sass": 89420
     }
@@ -185,11 +185,11 @@
     "size": 5533,
     "results": {
       "clean-css": 3287,
-      "csskit": 3281,
+      "csskit": 3280,
       "csslop": 2815,
       "cssnano": 3268,
       "csso": 3281,
-      "esbuild": 3297,
+      "esbuild": 3296,
       "lightningcss": 3324,
       "sass": 3313
     }
@@ -200,11 +200,11 @@
     "size": 21368,
     "results": {
       "clean-css": 7610,
-      "csskit": 8749,
+      "csskit": 8748,
       "csslop": 7555,
       "cssnano": 7457,
       "csso": 7380,
-      "esbuild": 7655,
+      "esbuild": 7654,
       "lightningcss": 7629,
       "sass": 8803
     }
@@ -215,13 +215,13 @@
     "size": 200387,
     "results": {
       "clean-css": 160082,
-      "csskit": 160454,
+      "csskit": 160453,
       "csslop": 147604,
       "cssnano": 157988,
       "csso": 160404,
-      "esbuild": 161002,
+      "esbuild": 161001,
       "lightningcss": 143919,
-      "sass": 163489
+      "sass": 163488
     }
   },
   {
@@ -230,13 +230,13 @@
     "size": 280308,
     "results": {
       "clean-css": 230252,
-      "csskit": 230386,
+      "csskit": 230385,
       "csslop": 220735,
       "cssnano": 228921,
       "csso": 228303,
-      "esbuild": 232386,
+      "esbuild": 232385,
       "lightningcss": 227135,
-      "sass": 235235
+      "sass": 235234
     }
   },
   {
@@ -245,11 +245,11 @@
     "size": 42334,
     "results": {
       "clean-css": 31411,
-      "csskit": 34740,
+      "csskit": 34739,
       "csslop": 26016,
       "cssnano": 32197,
       "csso": 30935,
-      "esbuild": 34803,
+      "esbuild": 34802,
       "lightningcss": 24577,
       "sass": 36906
     }
@@ -260,13 +260,13 @@
     "size": 160807,
     "results": {
       "clean-css": 70321,
-      "csskit": 95430,
+      "csskit": 95429,
       "csslop": 70316,
       "cssnano": 71362,
       "csso": 88137,
-      "esbuild": 92471,
+      "esbuild": 92470,
       "lightningcss": 70634,
-      "sass": 97745
+      "sass": 97744
     }
   },
   {
@@ -275,11 +275,11 @@
     "size": 24284,
     "results": {
       "clean-css": 19626,
-      "csskit": 19605,
+      "csskit": 19604,
       "csslop": 15986,
       "cssnano": 18475,
       "csso": 18952,
-      "esbuild": 19739,
+      "esbuild": 19738,
       "lightningcss": 17529,
       "sass": 19261
     }
@@ -290,11 +290,11 @@
     "size": 23296,
     "results": {
       "clean-css": 17924,
-      "csskit": 17929,
+      "csskit": 17928,
       "csslop": 17406,
       "cssnano": 17654,
       "csso": 18898,
-      "esbuild": 18016,
+      "esbuild": 18015,
       "lightningcss": 17661,
       "sass": 18172
     }
@@ -305,11 +305,11 @@
     "size": 233717,
     "results": {
       "clean-css": 183378,
-      "csskit": 183235,
+      "csskit": 183234,
       "csslop": 181909,
       "cssnano": 182439,
       "csso": 183048,
-      "esbuild": 184402,
+      "esbuild": 184401,
       "lightningcss": 183393,
       "sass": 185630
     }
@@ -320,13 +320,13 @@
     "size": 17050,
     "results": {
       "clean-css": 12603,
-      "csskit": 12817,
+      "csskit": 12816,
       "csslop": 11347,
       "cssnano": 12592,
       "csso": 12523,
-      "esbuild": 12750,
+      "esbuild": 12749,
       "lightningcss": 10773,
-      "sass": 12786
+      "sass": 12785
     }
   },
   {
@@ -335,11 +335,11 @@
     "size": 4735,
     "results": {
       "clean-css": 3471,
-      "csskit": 3573,
+      "csskit": 3572,
       "csslop": 3505,
       "cssnano": 2709,
       "csso": 3432,
-      "esbuild": 3442,
+      "esbuild": 3441,
       "lightningcss": 3497,
       "sass": 4179
     }
@@ -350,11 +350,11 @@
     "size": 23574,
     "results": {
       "clean-css": 8999,
-      "csskit": 20243,
+      "csskit": 20242,
       "csslop": 19856,
       "cssnano": 16766,
       "csso": 6676,
-      "esbuild": 20294,
+      "esbuild": 20293,
       "lightningcss": 20398,
       "sass": 21123
     }
@@ -365,11 +365,11 @@
     "size": 22330,
     "results": {
       "clean-css": 17013,
-      "csskit": 17672,
+      "csskit": 17671,
       "csslop": 15121,
       "cssnano": 16600,
       "csso": 16997,
-      "esbuild": 16934,
+      "esbuild": 16933,
       "lightningcss": 16140,
       "sass": "ERROR"
     }
@@ -380,11 +380,11 @@
     "size": 23103,
     "results": {
       "clean-css": 5872,
-      "csskit": 5680,
+      "csskit": 5679,
       "csslop": 5613,
       "cssnano": 5791,
       "csso": 5779,
-      "esbuild": 6088,
+      "esbuild": 6087,
       "lightningcss": 6006,
       "sass": 5968
     }
@@ -395,13 +395,13 @@
     "size": 49521,
     "results": {
       "clean-css": 46025,
-      "csskit": 45413,
+      "csskit": 45412,
       "csslop": 42474,
       "cssnano": 45101,
       "csso": 46496,
-      "esbuild": 46346,
+      "esbuild": 46345,
       "lightningcss": 43359,
-      "sass": 46630
+      "sass": 46629
     }
   },
   {
@@ -410,11 +410,11 @@
     "size": 143659,
     "results": {
       "clean-css": 111745,
-      "csskit": 122298,
+      "csskit": 122297,
       "csslop": 62321,
       "cssnano": 120966,
       "csso": 107066,
-      "esbuild": 121207,
+      "esbuild": 121206,
       "lightningcss": 28531,
       "sass": 123186
     }
@@ -425,13 +425,13 @@
     "size": 33239,
     "results": {
       "clean-css": 26284,
-      "csskit": 26429,
+      "csskit": 26428,
       "csslop": 13227,
       "cssnano": 25326,
       "csso": 25803,
-      "esbuild": 26194,
+      "esbuild": 26193,
       "lightningcss": 24213,
-      "sass": 27233
+      "sass": 27232
     }
   },
   {
@@ -440,11 +440,11 @@
     "size": 8075,
     "results": {
       "clean-css": 4243,
-      "csskit": 4212,
+      "csskit": 4211,
       "csslop": 3040,
       "cssnano": 4214,
       "csso": 4130,
-      "esbuild": 4217,
+      "esbuild": 4216,
       "lightningcss": 3487,
       "sass": 4281
     }
@@ -455,11 +455,11 @@
     "size": 293404,
     "results": {
       "clean-css": 238475,
-      "csskit": 237980,
+      "csskit": 237979,
       "csslop": 217041,
       "cssnano": 207316,
       "csso": 201411,
-      "esbuild": 240350,
+      "esbuild": 240349,
       "lightningcss": 199739,
       "sass": 241974
     }
@@ -470,11 +470,11 @@
     "size": 28706,
     "results": {
       "clean-css": 25106,
-      "csskit": 24301,
+      "csskit": 24300,
       "csslop": 12265,
       "cssnano": 24976,
       "csso": 25007,
-      "esbuild": 25074,
+      "esbuild": 25073,
       "lightningcss": 24744,
       "sass": 25133
     }
@@ -485,11 +485,11 @@
     "size": 68690,
     "results": {
       "clean-css": 62136,
-      "csskit": 62560,
+      "csskit": 62559,
       "csslop": 59549,
       "cssnano": 50326,
       "csso": 61982,
-      "esbuild": 62479,
+      "esbuild": 62478,
       "lightningcss": 59842,
       "sass": 62617
     }
@@ -500,13 +500,13 @@
     "size": 53970,
     "results": {
       "clean-css": 7678,
-      "csskit": 7738,
+      "csskit": 7737,
       "csslop": 7508,
       "cssnano": 107837,
       "csso": 7597,
-      "esbuild": 7775,
+      "esbuild": 7774,
       "lightningcss": 7488,
-      "sass": 7824
+      "sass": 7823
     }
   },
   {
@@ -515,11 +515,11 @@
     "size": 21440,
     "results": {
       "clean-css": 11126,
-      "csskit": 11174,
+      "csskit": 11173,
       "csslop": 11048,
       "cssnano": 10703,
       "csso": 10885,
-      "esbuild": 11329,
+      "esbuild": 11328,
       "lightningcss": 10939,
       "sass": 11313
     }
@@ -530,11 +530,11 @@
     "size": 6132,
     "results": {
       "clean-css": 2105,
-      "csskit": 2132,
+      "csskit": 2131,
       "csslop": 2111,
       "cssnano": 2192,
       "csso": 2093,
-      "esbuild": 2210,
+      "esbuild": 2209,
       "lightningcss": 2164,
       "sass": 2221
     }
@@ -545,11 +545,11 @@
     "size": 59294,
     "results": {
       "clean-css": 50058,
-      "csskit": 49588,
+      "csskit": 49587,
       "csslop": 44639,
       "cssnano": 48960,
       "csso": 49814,
-      "esbuild": 49570,
+      "esbuild": 49569,
       "lightningcss": 48261,
       "sass": 50756
     }
@@ -560,11 +560,11 @@
     "size": 78045,
     "results": {
       "clean-css": 61119,
-      "csskit": 61503,
+      "csskit": 61502,
       "csslop": 58863,
       "cssnano": 60622,
       "csso": 60797,
-      "esbuild": 62053,
+      "esbuild": 62052,
       "lightningcss": 65571,
       "sass": "ERROR"
     }
@@ -575,11 +575,11 @@
     "size": 149789,
     "results": {
       "clean-css": 116791,
-      "csskit": 119792,
+      "csskit": 119791,
       "csslop": 85914,
       "cssnano": 116981,
       "csso": 112457,
-      "esbuild": 118330,
+      "esbuild": 118329,
       "lightningcss": 75530,
       "sass": 120317
     }
@@ -590,13 +590,13 @@
     "size": 96797,
     "results": {
       "clean-css": 71548,
-      "csskit": 70787,
+      "csskit": 70786,
       "csslop": 68163,
       "cssnano": 69507,
       "csso": 71430,
-      "esbuild": 71439,
+      "esbuild": 71438,
       "lightningcss": 69741,
-      "sass": 72208
+      "sass": 72207
     }
   },
   {
@@ -605,11 +605,11 @@
     "size": 3543,
     "results": {
       "clean-css": 1342,
-      "csskit": 247,
+      "csskit": 245,
       "csslop": 1148,
       "cssnano": "ERROR",
       "csso": 1188,
-      "esbuild": 1669,
+      "esbuild": 1668,
       "lightningcss": "ERROR",
       "sass": "ERROR"
     }
@@ -620,11 +620,11 @@
     "size": 58457,
     "results": {
       "clean-css": 27567,
-      "csskit": "ERROR",
+      "csskit": 39632,
       "csslop": 38587,
       "cssnano": 38462,
       "csso": 18840,
-      "esbuild": 39363,
+      "esbuild": 39362,
       "lightningcss": "ERROR",
       "sass": "ERROR"
     }
@@ -635,13 +635,13 @@
     "size": 243978,
     "results": {
       "clean-css": 181879,
-      "csskit": 183234,
+      "csskit": 183233,
       "csslop": 131385,
       "cssnano": "ERROR",
       "csso": 179093,
-      "esbuild": 183748,
+      "esbuild": 183747,
       "lightningcss": 173050,
-      "sass": 187025
+      "sass": 187024
     }
   },
   {
@@ -650,11 +650,11 @@
     "size": 11006,
     "results": {
       "clean-css": 7120,
-      "csskit": 7442,
+      "csskit": 7441,
       "csslop": 5950,
       "cssnano": 7071,
       "csso": 7088,
-      "esbuild": 7093,
+      "esbuild": 7092,
       "lightningcss": 5465,
       "sass": 7114
     }
@@ -665,11 +665,11 @@
     "size": 112042,
     "results": {
       "clean-css": 76345,
-      "csskit": 74140,
+      "csskit": 74139,
       "csslop": 76292,
       "cssnano": 75782,
       "csso": 75516,
-      "esbuild": 78225,
+      "esbuild": 78224,
       "lightningcss": 68459,
       "sass": 87046
     }
@@ -680,13 +680,13 @@
     "size": 161298,
     "results": {
       "clean-css": 123428,
-      "csskit": 130972,
+      "csskit": 130971,
       "csslop": 116178,
       "cssnano": 121007,
       "csso": 122377,
-      "esbuild": 125638,
+      "esbuild": 125637,
       "lightningcss": "ERROR",
-      "sass": 131612
+      "sass": 131611
     }
   },
   {
@@ -695,11 +695,11 @@
     "size": 96841,
     "results": {
       "clean-css": 54613,
-      "csskit": 57112,
+      "csskit": 57111,
       "csslop": 51533,
       "cssnano": 54055,
       "csso": 55557,
-      "esbuild": 56314,
+      "esbuild": 56313,
       "lightningcss": "ERROR",
       "sass": 57605
     }
@@ -710,11 +710,11 @@
     "size": 12006,
     "results": {
       "clean-css": 7901,
-      "csskit": 9376,
+      "csskit": 9375,
       "csslop": 5829,
       "cssnano": 7788,
       "csso": 7768,
-      "esbuild": 7937,
+      "esbuild": 7936,
       "lightningcss": 5010,
       "sass": 9404
     }
@@ -725,11 +725,11 @@
     "size": 31067,
     "results": {
       "clean-css": 26829,
-      "csskit": 26797,
+      "csskit": 26796,
       "csslop": 23369,
       "cssnano": 25231,
       "csso": 26286,
-      "esbuild": 27130,
+      "esbuild": 27129,
       "lightningcss": 26325,
       "sass": 27204
     }
@@ -740,11 +740,11 @@
     "size": 52213,
     "results": {
       "clean-css": 41378,
-      "csskit": 41967,
+      "csskit": 41966,
       "csslop": 33968,
       "cssnano": "ERROR",
       "csso": 41059,
-      "esbuild": 41745,
+      "esbuild": 41744,
       "lightningcss": 40687,
       "sass": "ERROR"
     }
@@ -755,11 +755,11 @@
     "size": 45359,
     "results": {
       "clean-css": 36116,
-      "csskit": 38101,
+      "csskit": 38100,
       "csslop": 34453,
       "cssnano": 26071,
       "csso": 34957,
-      "esbuild": 34947,
+      "esbuild": 34946,
       "lightningcss": 34733,
       "sass": 34959
     }
@@ -770,13 +770,13 @@
     "size": 167127,
     "results": {
       "clean-css": 149626,
-      "csskit": 150208,
+      "csskit": 150207,
       "csslop": 140108,
       "cssnano": 147435,
       "csso": 149578,
-      "esbuild": 152745,
+      "esbuild": 152744,
       "lightningcss": "ERROR",
-      "sass": 152298
+      "sass": 152297
     }
   },
   {
@@ -785,11 +785,11 @@
     "size": 10139,
     "results": {
       "clean-css": 4748,
-      "csskit": 4929,
+      "csskit": 4928,
       "csslop": 4717,
       "cssnano": 4948,
       "csso": 4748,
-      "esbuild": 5060,
+      "esbuild": 5059,
       "lightningcss": 5059,
       "sass": 5146
     }
@@ -800,7 +800,7 @@
     "size": 7473,
     "results": {
       "clean-css": 3434,
-      "csskit": 3288,
+      "csskit": 3287,
       "csslop": 3108,
       "cssnano": "ERROR",
       "csso": 2933,
@@ -815,11 +815,11 @@
     "size": 10831,
     "results": {
       "clean-css": 7230,
-      "csskit": 7308,
+      "csskit": 7307,
       "csslop": 6785,
       "cssnano": 7229,
       "csso": 7373,
-      "esbuild": 7447,
+      "esbuild": 7446,
       "lightningcss": 7183,
       "sass": 7584
     }
@@ -830,11 +830,11 @@
     "size": 5233,
     "results": {
       "clean-css": 1266,
-      "csskit": 1093,
+      "csskit": 1092,
       "csslop": 1215,
       "cssnano": 1234,
       "csso": 1269,
-      "esbuild": 1244,
+      "esbuild": 1243,
       "lightningcss": 1217,
       "sass": 1326
     }
@@ -845,13 +845,13 @@
     "size": 77539,
     "results": {
       "clean-css": 60960,
-      "csskit": 63684,
+      "csskit": 63683,
       "csslop": 55339,
       "cssnano": 60454,
       "csso": 59119,
-      "esbuild": 63058,
+      "esbuild": 63057,
       "lightningcss": 58068,
-      "sass": 65089
+      "sass": 65088
     }
   },
   {
@@ -860,13 +860,13 @@
     "size": 16330,
     "results": {
       "clean-css": 13029,
-      "csskit": 13013,
+      "csskit": 13012,
       "csslop": 9029,
       "cssnano": 12802,
       "csso": 12408,
-      "esbuild": 12798,
+      "esbuild": 12797,
       "lightningcss": 9743,
-      "sass": 12971
+      "sass": 12970
     }
   },
   {
@@ -875,11 +875,11 @@
     "size": 15056,
     "results": {
       "clean-css": 13405,
-      "csskit": 12859,
+      "csskit": 12858,
       "csslop": 7210,
       "cssnano": 12401,
       "csso": 13390,
-      "esbuild": 13072,
+      "esbuild": 13071,
       "lightningcss": 8507,
       "sass": 13913
     }
@@ -890,11 +890,11 @@
     "size": 190180,
     "results": {
       "clean-css": 176419,
-      "csskit": 187318,
+      "csskit": 187317,
       "csslop": 112023,
       "cssnano": 184766,
       "csso": 177347,
-      "esbuild": 186540,
+      "esbuild": 186539,
       "lightningcss": 79408,
       "sass": 190346
     }
@@ -905,11 +905,11 @@
     "size": 56509,
     "results": {
       "clean-css": 39220,
-      "csskit": 42485,
+      "csskit": 42484,
       "csslop": 22409,
       "cssnano": 40731,
       "csso": 38048,
-      "esbuild": 41567,
+      "esbuild": 41566,
       "lightningcss": 20263,
       "sass": 43271
     }
@@ -920,11 +920,11 @@
     "size": 8259,
     "results": {
       "clean-css": 6945,
-      "csskit": 6860,
+      "csskit": 6859,
       "csslop": 6626,
       "cssnano": 6730,
       "csso": 6669,
-      "esbuild": 6882,
+      "esbuild": 6881,
       "lightningcss": 6843,
       "sass": 6995
     }
@@ -935,11 +935,11 @@
     "size": 3693,
     "results": {
       "clean-css": 3047,
-      "csskit": 3139,
+      "csskit": 3138,
       "csslop": 2761,
       "cssnano": 2841,
       "csso": 3037,
-      "esbuild": 3120,
+      "esbuild": 3119,
       "lightningcss": 3159,
       "sass": 3139
     }
@@ -950,13 +950,13 @@
     "size": 311662,
     "results": {
       "clean-css": 252550,
-      "csskit": 258150,
+      "csskit": 258149,
       "csslop": 231196,
       "cssnano": 248258,
       "csso": 252766,
-      "esbuild": 253588,
+      "esbuild": 253587,
       "lightningcss": 230137,
-      "sass": 259777
+      "sass": 259776
     }
   },
   {
@@ -965,11 +965,11 @@
     "size": 1107,
     "results": {
       "clean-css": 773,
-      "csskit": 774,
+      "csskit": 773,
       "csslop": 747,
       "cssnano": 772,
       "csso": 747,
-      "esbuild": 774,
+      "esbuild": 773,
       "lightningcss": 773,
       "sass": 773
     }
@@ -980,13 +980,13 @@
     "size": 20474,
     "results": {
       "clean-css": 14945,
-      "csskit": 17295,
+      "csskit": 17294,
       "csslop": 10040,
       "cssnano": 17121,
       "csso": 17215,
-      "esbuild": 17474,
+      "esbuild": 17473,
       "lightningcss": "ERROR",
-      "sass": 17860
+      "sass": 17859
     }
   },
   {
@@ -995,11 +995,11 @@
     "size": 8537,
     "results": {
       "clean-css": 5817,
-      "csskit": 6277,
+      "csskit": 6276,
       "csslop": 5668,
       "cssnano": 5272,
       "csso": 6005,
-      "esbuild": 6055,
+      "esbuild": 6054,
       "lightningcss": 5867,
       "sass": 6178
     }
@@ -1010,13 +1010,13 @@
     "size": 55940,
     "results": {
       "clean-css": 46654,
-      "csskit": 47231,
+      "csskit": 47230,
       "csslop": 44688,
       "cssnano": 45661,
       "csso": 46079,
-      "esbuild": 47178,
+      "esbuild": 47177,
       "lightningcss": 46299,
-      "sass": 47095
+      "sass": 47094
     }
   },
   {
@@ -1025,11 +1025,11 @@
     "size": 622,
     "results": {
       "clean-css": 478,
-      "csskit": 409,
+      "csskit": 408,
       "csslop": 469,
       "cssnano": 476,
       "csso": 479,
-      "esbuild": 479,
+      "esbuild": 478,
       "lightningcss": 477,
       "sass": 483
     }
@@ -1040,11 +1040,11 @@
     "size": 76016,
     "results": {
       "clean-css": "ERROR",
-      "csskit": 60735,
+      "csskit": 60734,
       "csslop": 55765,
       "cssnano": 60588,
       "csso": 44650,
-      "esbuild": 61364,
+      "esbuild": 61363,
       "lightningcss": 60852,
       "sass": 69210
     }
@@ -1055,13 +1055,13 @@
     "size": 13762,
     "results": {
       "clean-css": 10691,
-      "csskit": 10659,
+      "csskit": 10658,
       "csslop": 9602,
       "cssnano": 10350,
       "csso": 11352,
-      "esbuild": 10836,
+      "esbuild": 10835,
       "lightningcss": 9005,
-      "sass": 10796
+      "sass": 10795
     }
   },
   {
@@ -1070,11 +1070,11 @@
     "size": 2797,
     "results": {
       "clean-css": 2020,
-      "csskit": 2218,
+      "csskit": 2217,
       "csslop": 1558,
       "cssnano": 2218,
       "csso": 2004,
-      "esbuild": 2219,
+      "esbuild": 2218,
       "lightningcss": 2056,
       "sass": 2224
     }
@@ -1085,11 +1085,11 @@
     "size": 1222,
     "results": {
       "clean-css": 605,
-      "csskit": 619,
+      "csskit": 618,
       "csslop": 611,
       "cssnano": 607,
       "csso": 611,
-      "esbuild": 611,
+      "esbuild": 610,
       "lightningcss": 607,
       "sass": 619
     }
@@ -1100,11 +1100,11 @@
     "size": 10267,
     "results": {
       "clean-css": 8002,
-      "csskit": 8139,
+      "csskit": 8138,
       "csslop": 7973,
       "cssnano": 8005,
       "csso": 7804,
-      "esbuild": 8172,
+      "esbuild": 8171,
       "lightningcss": 8097,
       "sass": 8208
     }
@@ -1115,7 +1115,7 @@
     "size": 6505,
     "results": {
       "clean-css": 0,
-      "csskit": 2186,
+      "csskit": 2185,
       "csslop": 133,
       "cssnano": 0,
       "csso": 0,
@@ -1130,11 +1130,11 @@
     "size": 308246,
     "results": {
       "clean-css": 283568,
-      "csskit": 277499,
+      "csskit": 277498,
       "csslop": 279427,
       "cssnano": 282832,
       "csso": 279501,
-      "esbuild": 283174,
+      "esbuild": 283173,
       "lightningcss": 277460,
       "sass": 283885
     }
@@ -1145,11 +1145,11 @@
     "size": 6138,
     "results": {
       "clean-css": 1742,
-      "csskit": 1764,
+      "csskit": 1763,
       "csslop": 1695,
       "cssnano": 1792,
       "csso": 1692,
-      "esbuild": 1816,
+      "esbuild": 1815,
       "lightningcss": 1937,
       "sass": 1819
     }
@@ -1160,11 +1160,11 @@
     "size": 2036,
     "results": {
       "clean-css": 1737,
-      "csskit": 1552,
+      "csskit": 1551,
       "csslop": 1698,
       "cssnano": 1633,
       "csso": 1738,
-      "esbuild": 1699,
+      "esbuild": 1698,
       "lightningcss": 1699,
       "sass": 1794
     }
@@ -1175,11 +1175,11 @@
     "size": 17815,
     "results": {
       "clean-css": 13856,
-      "csskit": 12270,
+      "csskit": 12269,
       "csslop": 13515,
       "cssnano": 12016,
       "csso": 13856,
-      "esbuild": 12858,
+      "esbuild": 12857,
       "lightningcss": 12601,
       "sass": 12880
     }
@@ -1190,11 +1190,11 @@
     "size": 43210,
     "results": {
       "clean-css": 20582,
-      "csskit": 21298,
+      "csskit": 21297,
       "csslop": 20310,
       "cssnano": 21038,
       "csso": 19984,
-      "esbuild": 21077,
+      "esbuild": 21076,
       "lightningcss": 20983,
       "sass": 21764
     }
@@ -1205,13 +1205,13 @@
     "size": 155954,
     "results": {
       "clean-css": 132186,
-      "csskit": 131765,
+      "csskit": 131764,
       "csslop": 132623,
       "cssnano": 123610,
       "csso": 130283,
-      "esbuild": 127355,
+      "esbuild": 127354,
       "lightningcss": 131741,
-      "sass": 135480
+      "sass": 135479
     }
   },
   {
@@ -1220,11 +1220,11 @@
     "size": 1521,
     "results": {
       "clean-css": 1078,
-      "csskit": 1064,
+      "csskit": 1063,
       "csslop": 1070,
       "cssnano": 1071,
       "csso": 1076,
-      "esbuild": 1074,
+      "esbuild": 1073,
       "lightningcss": 1073,
       "sass": 1078
     }
@@ -1235,11 +1235,11 @@
     "size": 20080,
     "results": {
       "clean-css": 4608,
-      "csskit": 13104,
+      "csskit": 13103,
       "csslop": 9034,
       "cssnano": 4727,
       "csso": 4602,
-      "esbuild": 8595,
+      "esbuild": 8594,
       "lightningcss": 4659,
       "sass": 16072
     }
@@ -1250,13 +1250,13 @@
     "size": 32662,
     "results": {
       "clean-css": 24203,
-      "csskit": 23006,
+      "csskit": 23005,
       "csslop": 19831,
       "cssnano": 24020,
       "csso": 22943,
-      "esbuild": 24276,
+      "esbuild": 24275,
       "lightningcss": 20756,
-      "sass": 23465
+      "sass": 23464
     }
   },
   {
@@ -1265,13 +1265,13 @@
     "size": 58813,
     "results": {
       "clean-css": 38537,
-      "csskit": 39077,
+      "csskit": 39076,
       "csslop": 37268,
       "cssnano": 38267,
       "csso": 39523,
-      "esbuild": 39232,
+      "esbuild": 39231,
       "lightningcss": 37843,
-      "sass": 39535
+      "sass": 39534
     }
   },
   {
@@ -1280,13 +1280,13 @@
     "size": 97069,
     "results": {
       "clean-css": 86572,
-      "csskit": 86102,
+      "csskit": 86101,
       "csslop": 82607,
       "cssnano": 84126,
       "csso": 87845,
-      "esbuild": 87253,
+      "esbuild": 87252,
       "lightningcss": 86900,
-      "sass": 87531
+      "sass": 87530
     }
   },
   {
@@ -1295,11 +1295,11 @@
     "size": 6107,
     "results": {
       "clean-css": 4732,
-      "csskit": 4827,
+      "csskit": 4826,
       "csslop": 4741,
       "cssnano": 4793,
       "csso": 4825,
-      "esbuild": 4826,
+      "esbuild": 4825,
       "lightningcss": "ERROR",
       "sass": 4886
     }
@@ -1310,11 +1310,11 @@
     "size": 10914,
     "results": {
       "clean-css": 6924,
-      "csskit": 7163,
+      "csskit": 7162,
       "csslop": 6909,
       "cssnano": 7069,
       "csso": 7034,
-      "esbuild": 7177,
+      "esbuild": 7176,
       "lightningcss": 7185,
       "sass": 7270
     }
@@ -1325,13 +1325,13 @@
     "size": 17006,
     "results": {
       "clean-css": 7797,
-      "csskit": 7777,
+      "csskit": 7776,
       "csslop": 7365,
       "cssnano": 7855,
       "csso": 7807,
-      "esbuild": 7947,
+      "esbuild": 7946,
       "lightningcss": 7431,
-      "sass": 8123
+      "sass": 8122
     }
   },
   {
@@ -1340,11 +1340,11 @@
     "size": 22629,
     "results": {
       "clean-css": 18276,
-      "csskit": 18743,
+      "csskit": 18742,
       "csslop": 16033,
       "cssnano": 18722,
       "csso": 17379,
-      "esbuild": 18916,
+      "esbuild": 18915,
       "lightningcss": 14704,
       "sass": 19231
     }
@@ -1355,13 +1355,13 @@
     "size": 26207,
     "results": {
       "clean-css": 15422,
-      "csskit": 15479,
+      "csskit": 15478,
       "csslop": 15520,
       "cssnano": 15379,
       "csso": 15743,
-      "esbuild": 15683,
+      "esbuild": 15682,
       "lightningcss": 15511,
-      "sass": 15734
+      "sass": 15733
     }
   },
   {
@@ -1370,11 +1370,11 @@
     "size": 5098,
     "results": {
       "clean-css": 2087,
-      "csskit": 2748,
+      "csskit": 2747,
       "csslop": 1969,
       "cssnano": 2087,
       "csso": 2058,
-      "esbuild": 2088,
+      "esbuild": 2087,
       "lightningcss": 2087,
       "sass": 2824
     }
@@ -1385,13 +1385,13 @@
     "size": 24863,
     "results": {
       "clean-css": 20036,
-      "csskit": 19423,
+      "csskit": 19422,
       "csslop": 18057,
       "cssnano": 19845,
       "csso": 19947,
-      "esbuild": 20004,
+      "esbuild": 20003,
       "lightningcss": 18313,
-      "sass": 20034
+      "sass": 20033
     }
   },
   {
@@ -1400,13 +1400,13 @@
     "size": 21954,
     "results": {
       "clean-css": 8304,
-      "csskit": 11047,
+      "csskit": 11046,
       "csslop": 11046,
       "cssnano": 8304,
       "csso": 7925,
-      "esbuild": 14111,
+      "esbuild": 14110,
       "lightningcss": 8009,
-      "sass": 11575
+      "sass": 11574
     }
   },
   {
@@ -1415,11 +1415,11 @@
     "size": 4038,
     "results": {
       "clean-css": 738,
-      "csskit": 772,
+      "csskit": 771,
       "csslop": 765,
       "cssnano": 765,
       "csso": 751,
-      "esbuild": 766,
+      "esbuild": 765,
       "lightningcss": 765,
       "sass": 767
     }
@@ -1430,11 +1430,11 @@
     "size": 15985,
     "results": {
       "clean-css": 11839,
-      "csskit": 11800,
+      "csskit": 11799,
       "csslop": 5832,
       "cssnano": 11723,
       "csso": 11057,
-      "esbuild": 11706,
+      "esbuild": 11705,
       "lightningcss": 4340,
       "sass": 11879
     }
@@ -1445,11 +1445,11 @@
     "size": 2416,
     "results": {
       "clean-css": 1263,
-      "csskit": 1266,
+      "csskit": 1265,
       "csslop": 1258,
       "cssnano": 1261,
       "csso": 1264,
-      "esbuild": 1264,
+      "esbuild": 1263,
       "lightningcss": 1296,
       "sass": 1266
     }
@@ -1460,13 +1460,13 @@
     "size": 70886,
     "results": {
       "clean-css": 51410,
-      "csskit": 52658,
+      "csskit": 52657,
       "csslop": 50565,
       "cssnano": 51274,
       "csso": 51322,
-      "esbuild": 51908,
+      "esbuild": 51907,
       "lightningcss": 50500,
-      "sass": 52537
+      "sass": 52536
     }
   },
   {
@@ -1475,13 +1475,13 @@
     "size": 63129,
     "results": {
       "clean-css": 44951,
-      "csskit": 47136,
+      "csskit": 47135,
       "csslop": 44401,
       "cssnano": 45017,
       "csso": 44798,
-      "esbuild": 45508,
+      "esbuild": 45507,
       "lightningcss": 44642,
-      "sass": 46886
+      "sass": 46885
     }
   },
   {
@@ -1490,11 +1490,11 @@
     "size": 6769,
     "results": {
       "clean-css": 2236,
-      "csskit": 2342,
+      "csskit": 2341,
       "csslop": 2224,
       "cssnano": 2286,
       "csso": 2256,
-      "esbuild": 2297,
+      "esbuild": 2296,
       "lightningcss": 2418,
       "sass": 2322
     }
@@ -1505,11 +1505,11 @@
     "size": 4098,
     "results": {
       "clean-css": 2995,
-      "csskit": 3117,
+      "csskit": 3116,
       "csslop": 3023,
       "cssnano": 3029,
       "csso": 2818,
-      "esbuild": 3074,
+      "esbuild": 3073,
       "lightningcss": 3327,
       "sass": 3147
     }
@@ -1520,13 +1520,13 @@
     "size": 7267,
     "results": {
       "clean-css": 2187,
-      "csskit": 2181,
+      "csskit": 2180,
       "csslop": 2018,
       "cssnano": 2179,
       "csso": 2155,
-      "esbuild": 2181,
+      "esbuild": 2180,
       "lightningcss": 2052,
-      "sass": 2187
+      "sass": 2186
     }
   },
   {
@@ -1535,11 +1535,11 @@
     "size": 3161,
     "results": {
       "clean-css": 2099,
-      "csskit": 2097,
+      "csskit": 2096,
       "csslop": 1843,
       "cssnano": 2070,
       "csso": 2095,
-      "esbuild": 2070,
+      "esbuild": 2069,
       "lightningcss": 2005,
       "sass": 2118
     }
@@ -1550,11 +1550,11 @@
     "size": 113246,
     "results": {
       "clean-css": 94865,
-      "csskit": 93821,
+      "csskit": 93820,
       "csslop": 89989,
       "cssnano": 91463,
       "csso": 94308,
-      "esbuild": 94020,
+      "esbuild": 94019,
       "lightningcss": 91235,
       "sass": 97168
     }
@@ -1565,11 +1565,11 @@
     "size": 51645,
     "results": {
       "clean-css": 32817,
-      "csskit": 33416,
+      "csskit": 33415,
       "csslop": 26982,
       "cssnano": 32880,
       "csso": 32213,
-      "esbuild": 33352,
+      "esbuild": 33351,
       "lightningcss": 22944,
       "sass": 33752
     }
@@ -1580,11 +1580,11 @@
     "size": 2513,
     "results": {
       "clean-css": 1673,
-      "csskit": 1673,
+      "csskit": 1672,
       "csslop": 1652,
       "cssnano": 1672,
       "csso": 1658,
-      "esbuild": 1669,
+      "esbuild": 1668,
       "lightningcss": 1660,
       "sass": 1674
     }
@@ -1595,13 +1595,13 @@
     "size": 12973,
     "results": {
       "clean-css": 10955,
-      "csskit": 10205,
+      "csskit": 10204,
       "csslop": 10187,
       "cssnano": 10943,
       "csso": 10186,
-      "esbuild": 10944,
+      "esbuild": 10943,
       "lightningcss": 10182,
-      "sass": 10210
+      "sass": 10209
     }
   },
   {
@@ -1610,11 +1610,11 @@
     "size": 14088,
     "results": {
       "clean-css": 9654,
-      "csskit": 9857,
+      "csskit": 9856,
       "csslop": 9694,
       "cssnano": 9640,
       "csso": 9579,
-      "esbuild": 9853,
+      "esbuild": 9852,
       "lightningcss": 9694,
       "sass": 9893
     }
@@ -1625,11 +1625,11 @@
     "size": 9952,
     "results": {
       "clean-css": 5834,
-      "csskit": 6000,
+      "csskit": 5999,
       "csslop": 5646,
       "cssnano": 5852,
       "csso": 5807,
-      "esbuild": 5875,
+      "esbuild": 5874,
       "lightningcss": 5722,
       "sass": 5891
     }
@@ -1640,11 +1640,11 @@
     "size": 1793,
     "results": {
       "clean-css": 1362,
-      "csskit": 1367,
+      "csskit": 1366,
       "csslop": 1317,
       "cssnano": 1222,
       "csso": 1369,
-      "esbuild": 1369,
+      "esbuild": 1368,
       "lightningcss": 1342,
       "sass": 1371
     }
@@ -1655,13 +1655,13 @@
     "size": 62360,
     "results": {
       "clean-css": 46336,
-      "csskit": 46037,
+      "csskit": 46036,
       "csslop": 43514,
       "cssnano": 45677,
       "csso": 45780,
-      "esbuild": 46267,
+      "esbuild": 46266,
       "lightningcss": 44257,
-      "sass": 46895
+      "sass": 46894
     }
   },
   {
@@ -1670,11 +1670,11 @@
     "size": 25863,
     "results": {
       "clean-css": 20776,
-      "csskit": 20947,
+      "csskit": 20946,
       "csslop": 20096,
       "cssnano": 19562,
       "csso": 20457,
-      "esbuild": 20960,
+      "esbuild": 20959,
       "lightningcss": 20456,
       "sass": 21278
     }
@@ -1685,13 +1685,13 @@
     "size": 34970,
     "results": {
       "clean-css": 27828,
-      "csskit": 27897,
+      "csskit": 27896,
       "csslop": 27024,
       "cssnano": 27573,
       "csso": 27844,
-      "esbuild": 28310,
+      "esbuild": 28309,
       "lightningcss": 27655,
-      "sass": 28128
+      "sass": 28127
     }
   },
   {
@@ -1700,11 +1700,11 @@
     "size": 14783,
     "results": {
       "clean-css": 9496,
-      "csskit": 9497,
+      "csskit": 9496,
       "csslop": 7895,
       "cssnano": 9464,
       "csso": 9223,
-      "esbuild": 9467,
+      "esbuild": 9466,
       "lightningcss": 9436,
       "sass": 9584
     }
@@ -1715,11 +1715,11 @@
     "size": 17664,
     "results": {
       "clean-css": 14549,
-      "csskit": 14681,
+      "csskit": 14680,
       "csslop": 13403,
       "cssnano": 14313,
       "csso": 13808,
-      "esbuild": 14538,
+      "esbuild": 14537,
       "lightningcss": 14412,
       "sass": 14691
     }
@@ -1730,11 +1730,11 @@
     "size": 11041,
     "results": {
       "clean-css": 9402,
-      "csskit": 9787,
+      "csskit": 9786,
       "csslop": 8224,
       "cssnano": "ERROR",
       "csso": 9329,
-      "esbuild": 9683,
+      "esbuild": 9682,
       "lightningcss": "ERROR",
       "sass": "ERROR"
     }
@@ -1745,11 +1745,11 @@
     "size": 114983,
     "results": {
       "clean-css": 73999,
-      "csskit": 75330,
+      "csskit": 75329,
       "csslop": 71354,
       "cssnano": 72657,
       "csso": 76267,
-      "esbuild": 75207,
+      "esbuild": 75206,
       "lightningcss": "ERROR",
       "sass": 76981
     }
@@ -1760,11 +1760,11 @@
     "size": 2901,
     "results": {
       "clean-css": 944,
-      "csskit": 950,
+      "csskit": 949,
       "csslop": 888,
       "cssnano": 942,
       "csso": 944,
-      "esbuild": 946,
+      "esbuild": 945,
       "lightningcss": 859,
       "sass": 947
     }
@@ -1775,11 +1775,11 @@
     "size": 7274,
     "results": {
       "clean-css": 5221,
-      "csskit": 5219,
+      "csskit": 5218,
       "csslop": 5091,
       "cssnano": 5204,
       "csso": 5196,
-      "esbuild": 5218,
+      "esbuild": 5217,
       "lightningcss": 5161,
       "sass": 5207
     }
@@ -1790,11 +1790,11 @@
     "size": 6291,
     "results": {
       "clean-css": 5156,
-      "csskit": 5392,
+      "csskit": 5391,
       "csslop": 3497,
       "cssnano": 5331,
       "csso": 5137,
-      "esbuild": 5427,
+      "esbuild": 5426,
       "lightningcss": 5282,
       "sass": 5441
     }
@@ -1805,11 +1805,11 @@
     "size": 11212,
     "results": {
       "clean-css": 8340,
-      "csskit": 8386,
+      "csskit": 8385,
       "csslop": 7874,
       "cssnano": 8155,
       "csso": 8119,
-      "esbuild": 8318,
+      "esbuild": 8317,
       "lightningcss": 8311,
       "sass": 8410
     }
@@ -1820,13 +1820,13 @@
     "size": 46295,
     "results": {
       "clean-css": 34197,
-      "csskit": 33746,
+      "csskit": 33745,
       "csslop": 31420,
       "cssnano": 33685,
       "csso": 30864,
-      "esbuild": 34362,
+      "esbuild": 34361,
       "lightningcss": 32564,
-      "sass": 34817
+      "sass": 34816
     }
   },
   {
@@ -1835,11 +1835,11 @@
     "size": 17423,
     "results": {
       "clean-css": 9328,
-      "csskit": 14517,
+      "csskit": 14516,
       "csslop": 12847,
       "cssnano": 14819,
       "csso": 8529,
-      "esbuild": 15569,
+      "esbuild": 15568,
       "lightningcss": 15252,
       "sass": "ERROR"
     }
@@ -1850,13 +1850,13 @@
     "size": 400726,
     "results": {
       "clean-css": 280294,
-      "csskit": "ERROR",
+      "csskit": 285176,
       "csslop": 279312,
       "cssnano": 275665,
       "csso": 279768,
-      "esbuild": 281132,
+      "esbuild": 281131,
       "lightningcss": 281124,
-      "sass": 284486
+      "sass": 284485
     }
   },
   {
@@ -1865,11 +1865,11 @@
     "size": 12210,
     "results": {
       "clean-css": 9159,
-      "csskit": 9245,
+      "csskit": 9244,
       "csslop": 8541,
       "cssnano": 8981,
       "csso": 9061,
-      "esbuild": 9296,
+      "esbuild": 9295,
       "lightningcss": 9026,
       "sass": 9273
     }
@@ -1880,11 +1880,11 @@
     "size": 71707,
     "results": {
       "clean-css": 57864,
-      "csskit": 57325,
+      "csskit": 57324,
       "csslop": 48063,
       "cssnano": 55248,
       "csso": 54624,
-      "esbuild": 56901,
+      "esbuild": 56900,
       "lightningcss": 27319,
       "sass": 60598
     }
@@ -1895,11 +1895,11 @@
     "size": 4735,
     "results": {
       "clean-css": 3471,
-      "csskit": 3573,
+      "csskit": 3572,
       "csslop": 3505,
       "cssnano": 2709,
       "csso": 3432,
-      "esbuild": 3442,
+      "esbuild": 3441,
       "lightningcss": 3497,
       "sass": 4179
     }
@@ -1910,13 +1910,13 @@
     "size": 32362,
     "results": {
       "clean-css": 17126,
-      "csskit": 26973,
+      "csskit": 26972,
       "csslop": 21905,
       "cssnano": 22854,
       "csso": 21202,
-      "esbuild": 26068,
+      "esbuild": 26067,
       "lightningcss": 24428,
-      "sass": 27388
+      "sass": 27387
     }
   },
   {
@@ -1925,13 +1925,13 @@
     "size": 175928,
     "results": {
       "clean-css": 148831,
-      "csskit": 149532,
+      "csskit": 149531,
       "csslop": 127795,
       "cssnano": 149226,
       "csso": 146557,
-      "esbuild": 151549,
+      "esbuild": 151548,
       "lightningcss": 57969,
-      "sass": 150425
+      "sass": 150424
     }
   },
   {
@@ -1940,11 +1940,11 @@
     "size": 22908,
     "results": {
       "clean-css": 16445,
-      "csskit": 16711,
+      "csskit": 16710,
       "csslop": 15237,
       "cssnano": 14954,
       "csso": 16468,
-      "esbuild": 14837,
+      "esbuild": 14836,
       "lightningcss": 15516,
       "sass": 17371
     }
@@ -1955,13 +1955,13 @@
     "size": 4547,
     "results": {
       "clean-css": 3397,
-      "csskit": 3717,
+      "csskit": 3716,
       "csslop": 2608,
       "cssnano": 3453,
       "csso": 3236,
-      "esbuild": 3748,
+      "esbuild": 3747,
       "lightningcss": 3214,
-      "sass": 3794
+      "sass": 3793
     }
   },
   {
@@ -1970,11 +1970,11 @@
     "size": 8355,
     "results": {
       "clean-css": 5815,
-      "csskit": 5792,
+      "csskit": 5791,
       "csslop": 5568,
       "cssnano": 5785,
       "csso": 5770,
-      "esbuild": 5829,
+      "esbuild": 5828,
       "lightningcss": 5720,
       "sass": 5855
     }
@@ -1985,11 +1985,11 @@
     "size": 10548,
     "results": {
       "clean-css": 7855,
-      "csskit": 7847,
+      "csskit": 7846,
       "csslop": 7499,
       "cssnano": 5670,
       "csso": 7734,
-      "esbuild": 7880,
+      "esbuild": 7879,
       "lightningcss": "ERROR",
       "sass": 7895
     }
@@ -2000,11 +2000,11 @@
     "size": 13440,
     "results": {
       "clean-css": 9130,
-      "csskit": 9715,
+      "csskit": 9714,
       "csslop": 9113,
       "cssnano": 9111,
       "csso": 8068,
-      "esbuild": 9508,
+      "esbuild": 9507,
       "lightningcss": 8914,
       "sass": 10103
     }

--- a/data/results-history.json
+++ b/data/results-history.json
@@ -1,5 +1,51 @@
 [
   {
+    "date": "2026-06-17T11:06:12.946Z",
+    "testCount": 412,
+    "minifiers": {
+      "clean-css": {
+        "version": "5.3.3",
+        "pass": 154,
+        "total": 412
+      },
+      "csskit": {
+        "version": "0.0.25",
+        "pass": 172,
+        "total": 412
+      },
+      "csslop": {
+        "version": "0.0.5",
+        "pass": 412,
+        "total": 412
+      },
+      "cssnano": {
+        "version": "8.0.2",
+        "pass": 214,
+        "total": 412
+      },
+      "csso": {
+        "version": "5.0.5",
+        "pass": 156,
+        "total": 412
+      },
+      "esbuild": {
+        "version": "0.28.1",
+        "pass": 191,
+        "total": 412
+      },
+      "lightningcss": {
+        "version": "1.32.0",
+        "pass": 281,
+        "total": 412
+      },
+      "sass": {
+        "version": "1.101.0",
+        "pass": 125,
+        "total": 412
+      }
+    }
+  },
+  {
     "date": "2026-06-17T10:01:19.815Z",
     "testCount": 412,
     "minifiers": {

--- a/data/results-history.json
+++ b/data/results-history.json
@@ -1,5 +1,51 @@
 [
   {
+    "date": "2026-06-16T21:25:20.094Z",
+    "testCount": 412,
+    "minifiers": {
+      "clean-css": {
+        "version": "5.3.3",
+        "pass": 154,
+        "total": 412
+      },
+      "csskit": {
+        "version": "0.0.25",
+        "pass": 172,
+        "total": 412
+      },
+      "csslop": {
+        "version": "0.0.5",
+        "pass": 412,
+        "total": 412
+      },
+      "cssnano": {
+        "version": "8.0.2",
+        "pass": 214,
+        "total": 412
+      },
+      "csso": {
+        "version": "5.0.5",
+        "pass": 156,
+        "total": 412
+      },
+      "esbuild": {
+        "version": "0.28.1",
+        "pass": 191,
+        "total": 412
+      },
+      "lightningcss": {
+        "version": "1.32.0",
+        "pass": 281,
+        "total": 412
+      },
+      "sass": {
+        "version": "1.101.0",
+        "pass": 125,
+        "total": 412
+      }
+    }
+  },
+  {
     "date": "2026-06-10T16:01:57.454Z",
     "testCount": 412,
     "minifiers": {

--- a/data/results.json
+++ b/data/results.json
@@ -807,7 +807,7 @@
     "csso": true,
     "esbuild": false,
     "lightningcss": true,
-    "sass": false
+    "sass": true
   },
   "counter-style/0002": {
     "clean-css": true,

--- a/lib/createWebsite/makeRealWorldTable.js
+++ b/lib/createWebsite/makeRealWorldTable.js
@@ -351,7 +351,7 @@ const makeSizeTable = function (results) {
           ${allTotals}
         </tr>
         <tr>
-          <th>Total Percents</th>
+          <th>Percent Reduction</th>
           ${allPercents}
         </tr>
         <tr>

--- a/lib/loaders/loadAllMinifiers.js
+++ b/lib/loaders/loadAllMinifiers.js
@@ -3,14 +3,14 @@
  *       over them in tests.
  */
 
-import cleanCss from "../minifiers/clean-css.js";
-import csslop from "../minifiers/csslop.js";
-import csskit from "../minifiers/csskit.js";
-import cssnano from "../minifiers/cssnano.js";
-import csso from "../minifiers/csso.js";
-import esbuild from "../minifiers/esbuild.js";
-import lightningcss from "../minifiers/lightningcss.js";
-import sass from "../minifiers/sass.js";
+import cleanCss from '../minifiers/clean-css.js';
+import csslop from '../minifiers/csslop.js';
+import csskit from '../minifiers/csskit.js';
+import cssnano from '../minifiers/cssnano.js';
+import csso from '../minifiers/csso.js';
+import esbuild from '../minifiers/esbuild.js';
+import lightningcss from '../minifiers/lightningcss.js';
+import sass from '../minifiers/sass.js';
 
 /**
  * The key is the npm package name, used for version lookups and displaying in
@@ -19,14 +19,14 @@ import sass from "../minifiers/sass.js";
  * @type {Map}
  */
 export const registry = new Map([
-  ["clean-css", cleanCss],
-  ["csskit", csskit],
-  ["csslop", csslop],
-  ["cssnano", cssnano],
-  ["csso", csso],
-  ["esbuild", esbuild],
-  ["lightningcss", lightningcss],
-  ["sass", sass],
+  ['clean-css', cleanCss],
+  ['csskit', csskit],
+  ['csslop', csslop],
+  ['cssnano', cssnano],
+  ['csso', csso],
+  ['esbuild', esbuild],
+  ['lightningcss', lightningcss],
+  ['sass', sass]
 ]);
 
 /**
@@ -35,3 +35,24 @@ export const registry = new Map([
  * @type {string[]}  ['clean-css', 'csskit', ...]
  */
 export const minifiers = [...registry.keys()];
+
+/**
+ * Returns a minifier name's official orthographie including
+ * correct capitalization.
+ *
+ * @param  {string} minifierName  The minifier name defined in the above registry
+ * @return {string}               The official title-cased version
+ */
+export const getMinifierTitle = function (minifierName) {
+  const minifierTitleNameMap = {
+    'clean-css': 'CleanCSS',
+    csskit: 'csskit',
+    csslop: 'CSSLOP',
+    cssnano: 'cssnano',
+    csso: 'CSS Optimizer',
+    esbuild: 'esbuild',
+    lightningcss: 'Lightning CSS',
+    sass: 'Sass'
+  };
+  return minifierTitleNameMap[minifierName] || minifierName;
+};

--- a/lib/minifiers/clean-css.js
+++ b/lib/minifiers/clean-css.js
@@ -1,11 +1,11 @@
-import CleanCSS from "clean-css";
+import CleanCSS from 'clean-css';
 
 const instance = new CleanCSS({ level: 2, inline: false });
 
-export default function minify(source) {
+export default function minify (source) {
   const result = instance.minify(source);
   if (result.errors?.length) {
-    throw new Error(result.errors.join("\n"));
+    throw new Error(result.errors.join('\n'));
   }
   return result.styles;
 }

--- a/lib/minifiers/csskit.js
+++ b/lib/minifiers/csskit.js
@@ -1,71 +1,70 @@
-import { execSync } from "node:child_process";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const __dirname = import.meta.dirname;
 
 let bin;
 
-const PLATFORM_PACKAGES = {
-  "linux-x64": "csskit-linux-x64",
-  "linux-arm64": "csskit-linux-arm64",
-  "darwin-x64": "csskit-darwin-x64",
-  "darwin-arm64": "csskit-darwin-arm64",
-  "win32-x64": "csskit-win32-x64",
-  "win32-arm64": "csskit-win32-arm64",
-};
+function findBin () {
+  const PLATFORM_PACKAGES = {
+    'linux-x64': 'csskit-linux-x64',
+    'linux-arm64': 'csskit-linux-arm64',
+    'darwin-x64': 'csskit-darwin-x64',
+    'darwin-arm64': 'csskit-darwin-arm64',
+    'win32-x64': 'csskit-win32-x64',
+    'win32-arm64': 'csskit-win32-arm64'
+  };
+  if (bin !== undefined) {
+    return;
+  };
 
-function findBin() {
-  if (bin !== undefined) return bin;
-
-  const nodeModules = path.resolve(
-    import.meta.dirname,
-    "..",
-    "..",
-    "node_modules",
-  );
+  const nodeModules = path.resolve(__dirname, '..', '..', 'node_modules');
 
   // Try the .bin symlink first (works when npm links it correctly)
-  const npmBin = path.join(nodeModules, ".bin", "csskit");
+  const npmBin = path.join(nodeModules, '.bin', 'csskit');
   try {
-    execSync(`"${npmBin}" --version`, { stdio: "pipe" });
+    execSync(npmBin + ' --version', { stdio: 'pipe' });
     bin = npmBin;
-    return bin;
+    return;
   } catch {}
 
   // Resolve platform binary directly (npm sometimes skips creating .bin links)
-  const key = `${os.platform()}-${os.arch()}`;
+  const key = os.platform() + '-' + os.arch();
   const pkg = PLATFORM_PACKAGES[key];
+  let file = 'csskit';
+  if (os.platform() === 'win32') {
+    file = 'csskit.exe';
+  }
   if (pkg) {
-    const platformBin = path.join(
-      nodeModules,
-      pkg,
-      "bin",
-      os.platform() === "win32" ? "csskit.exe" : "csskit",
-    );
+    const platformBin = path.join(nodeModules, pkg, 'bin', file);
     if (fs.existsSync(platformBin)) {
       bin = platformBin;
-      return bin;
+      return;
     }
   }
 
   // Fall back to PATH
   try {
-    execSync("csskit --version", { stdio: "pipe" });
-    bin = "csskit";
-    return bin;
+    execSync('csskit --version', { stdio: 'pipe' });
+    bin = 'csskit';
+    return;
   } catch {
     bin = null;
-    return bin;
+    return;
   }
 }
+findBin();
 
-export default function minify(source) {
-  const resolved = findBin();
-  if (!resolved) return null;
+export default function minify (source) {
+  if (!bin) {
+    return null
+  };
 
-  return execSync(`"${resolved}" min -`, {
+  return execSync(`"${bin}" min -`, {
     input: source,
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe']
   });
 }

--- a/lib/minifiers/csslop.js
+++ b/lib/minifiers/csslop.js
@@ -1,5 +1,5 @@
 import { minifyCSS } from '@thejaredwilcurt/csslop';
 
-export default function minify(source) {
+export default function minify (source) {
   return minifyCSS(source);
-};
+}

--- a/lib/minifiers/cssnano.js
+++ b/lib/minifiers/cssnano.js
@@ -1,9 +1,9 @@
-import postcss from "postcss";
-import cssnano from "cssnano";
+import postcss from 'postcss';
+import cssnano from 'cssnano';
 
 const processor = postcss([cssnano]);
 
-export default async function minify(source) {
+export default async function minify (source) {
   const result = await processor.process(source, { from: undefined });
   return result.css;
 }

--- a/lib/minifiers/csso.js
+++ b/lib/minifiers/csso.js
@@ -1,5 +1,5 @@
-import { minify as cssoMinify } from "csso";
+import { minify as cssoMinify } from 'csso';
 
-export default function minify(source) {
+export default function minify (source) {
   return cssoMinify(source).css;
 }

--- a/lib/minifiers/esbuild.js
+++ b/lib/minifiers/esbuild.js
@@ -1,10 +1,14 @@
-import { transform } from "esbuild";
+import { transform } from 'esbuild';
 
-export default async function minify(source) {
+export default async function minify (source) {
   const { code } = await transform(source, {
-    loader: "css",
+    loader: 'css',
     minify: true,
-    target: ["chrome130", "firefox130", "safari18"],
+    target: [
+      'chrome149',
+      'firefox151',
+      'safari26'
+    ]
   });
   return code;
 }

--- a/lib/minifiers/lightningcss.js
+++ b/lib/minifiers/lightningcss.js
@@ -1,14 +1,14 @@
-import { transform, browserslistToTargets } from "lightningcss";
+import { transform, browserslistToTargets } from 'lightningcss';
 
 const targets = browserslistToTargets([
-  "last 1 Chrome version",
-  "last 1 Firefox version",
-  "last 1 Safari version",
+  'last 1 Chrome version',
+  'last 1 Firefox version',
+  'last 1 Safari version',
 ]);
 
-export default function minify(source) {
+export default function minify (source) {
   const { code } = transform({
-    filename: "test.css",
+    filename: 'test.css',
     code: Buffer.from(source),
     minify: true,
     targets,

--- a/lib/minifiers/sass.js
+++ b/lib/minifiers/sass.js
@@ -1,5 +1,9 @@
-import { compileString } from "sass";
+import { compileString } from 'sass';
 
-export default function minify(source) {
-  return compileString(source, { style: "compressed" }).css;
-};
+export default function minify (source) {
+  const options = {
+    style: 'compressed',
+    alertColor: false
+  };
+  return compileString(source, options).css;
+}

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -1,33 +1,34 @@
-import fs from "node:fs";
-import path from "node:path";
+import fs from 'node:fs';
+import path from 'node:path';
 
-import { minifiers, registry } from "./loaders/loadAllMinifiers.js";
+import { minifiers, registry } from './loaders/loadAllMinifiers.js';
 
-export async function minify(name, source) {
+export async function minify (name, source) {
   const fn = registry.get(name);
   if (!fn) throw new Error(`Unknown minifier: ${name}`);
-  return fn(source);
+  const output = await fn(source);
+  return output.trim();
 }
 
-export function getVersions(names = minifiers) {
+export function getVersions (names = minifiers) {
   const versions = {};
   const scopedPackages = {
-    csslop: "@thejaredwilcurt"
+    csslop: '@thejaredwilcurt'
   };
   for (let name of names) {
     const pathParts = [
       import.meta.dirname,
-      "..",
-      "node_modules"
+      '..',
+      'node_modules'
     ];
     if (scopedPackages[name]) {
       pathParts.push(scopedPackages[name]);
     }
     pathParts.push(name);
-    pathParts.push("package.json");
+    pathParts.push('package.json');
     try {
       const pkgPath = path.resolve(...pathParts);
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
       versions[name] = pkg.version;
     } catch {
       versions[name] = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,18 @@
       "devDependencies": {
         "@thejaredwilcurt/csslop": "^0.0.5",
         "clean-css": "^5.3.3",
-        "csskit": "^0.0.24",
-        "cssnano": "^8.0.1",
+        "cross-env": "^10.1.0",
+        "csskit": "^0.0.25",
+        "cssnano": "^8.0.2",
         "csso": "^5.0.5",
-        "esbuild": "^0.28.0",
+        "esbuild": "^0.28.1",
         "http-server": "^14.1.1",
         "lightningcss": "^1.30.0",
         "marked": "^18.0.5",
         "postcss": "^8.5.15",
         "pretty-ms": "^9.3.0",
         "real-world-css-libraries": "^1.0.2",
-        "sass": "^1.100.0",
+        "sass": "^1.101.0",
         "shiki": "^4.2.0"
       }
     },
@@ -100,10 +101,17 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -118,9 +126,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -135,9 +143,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -152,9 +160,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -169,9 +177,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -186,9 +194,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -203,9 +211,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -220,9 +228,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -237,9 +245,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -254,9 +262,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -271,9 +279,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -288,9 +296,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -305,9 +313,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -322,9 +330,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -339,9 +347,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -356,9 +364,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -373,9 +381,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -390,9 +398,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -407,9 +415,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -424,9 +432,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -441,9 +449,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -458,9 +466,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -475,9 +483,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -492,9 +500,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -509,9 +517,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -526,9 +534,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1053,9 +1061,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1151,22 +1159,20 @@
       }
     },
     "node_modules/caniuse-api": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
-      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-4.0.0.tgz",
+      "integrity": "sha512-B0hQ1OLyJuHTQSOWXvwibWqM6DCoqJdvBA6X1S/53bd4XU7LJ1yurIPlrsouol3mw1jh9pGI4ivubSpmJeIqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
+        "caniuse-lite": "^1.0.0"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -1314,6 +1320,39 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -1373,9 +1412,9 @@
       }
     },
     "node_modules/csskit": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/csskit/-/csskit-0.0.24.tgz",
-      "integrity": "sha512-hXc1Uml2hFi8Gm5It1fYUaOTLwuS3FKbbzgnwox0nN+RsFDvTtJ54HP/0yAviTciwXO4IZworA+LxUw1OqRsmg==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/csskit/-/csskit-0.0.25.tgz",
+      "integrity": "sha512-0OJdwLPzaOYtx6TOfLlNIqfQqMEHVtWnrdp5z5Fr/cw1IXCuJpiWidlulEoF5tsbyPoYitIB2Lkv/zfLIoH5BQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1385,18 +1424,18 @@
         "url": "https://github.com/sponsors/keithamus"
       },
       "optionalDependencies": {
-        "csskit-darwin-arm64": "0.0.24",
-        "csskit-darwin-x64": "0.0.24",
-        "csskit-linux-arm64": "0.0.24",
-        "csskit-linux-x64": "0.0.24",
-        "csskit-win32-arm64": "0.0.24",
-        "csskit-win32-x64": "0.0.24"
+        "csskit-darwin-arm64": "0.0.25",
+        "csskit-darwin-x64": "0.0.25",
+        "csskit-linux-arm64": "0.0.25",
+        "csskit-linux-x64": "0.0.25",
+        "csskit-win32-arm64": "0.0.25",
+        "csskit-win32-x64": "0.0.25"
       }
     },
     "node_modules/csskit-darwin-arm64": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/csskit-darwin-arm64/-/csskit-darwin-arm64-0.0.24.tgz",
-      "integrity": "sha512-gF/y5iWnpHNiLZXxa38nmyndbF78xX4Ly5k3Be4qwf2Dojac8GBTzxp89PRGrZPt6nF2S5bd+DgDqSreDzmu0g==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/csskit-darwin-arm64/-/csskit-darwin-arm64-0.0.25.tgz",
+      "integrity": "sha512-sifopphI6VCrVv3WlFgGmZU4QmEslGk28SFqYeUCUV8922bZIuFZU7/KR5W0QOuLRw6tFffzjS/MoycOaunblw==",
       "cpu": [
         "arm64"
       ],
@@ -1414,9 +1453,9 @@
       }
     },
     "node_modules/csskit-darwin-x64": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/csskit-darwin-x64/-/csskit-darwin-x64-0.0.24.tgz",
-      "integrity": "sha512-naQJd70xyyYQv61UKsZRIhs/NVbO4ebaFTYU3konybCA9LI19nNP37QzD8OETpdGuQAQiJ6GwmatGTv6s0Ancw==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/csskit-darwin-x64/-/csskit-darwin-x64-0.0.25.tgz",
+      "integrity": "sha512-knIoVkrfabS3KvjrtgpjIl5Bfz/iD5yvc/hfv8njsuidf9v3n5KqSX9Soia6dOGfZeq0kml/z9Pz66o8EzcodQ==",
       "cpu": [
         "x64"
       ],
@@ -1434,9 +1473,9 @@
       }
     },
     "node_modules/csskit-linux-arm64": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/csskit-linux-arm64/-/csskit-linux-arm64-0.0.24.tgz",
-      "integrity": "sha512-wXiGVkAqs0uszO4Pl+iNLZJkeAxQgVc/VWaZVwdMQrgvgz6aM42FavBsXwtyARFB0FCv9BJhrWmf2aZv3hsDXw==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/csskit-linux-arm64/-/csskit-linux-arm64-0.0.25.tgz",
+      "integrity": "sha512-5MItwUAqAAHjpL9WoyUEpETHsL5DManJ8b05ZjW1KfsF6GsxEQ+JJWar71JMQxFw14/MGYl/mlDKYvIeJpkOYQ==",
       "cpu": [
         "arm64"
       ],
@@ -1454,9 +1493,9 @@
       }
     },
     "node_modules/csskit-linux-x64": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/csskit-linux-x64/-/csskit-linux-x64-0.0.24.tgz",
-      "integrity": "sha512-EoIHIxUHPoLLrHyh8w4QAxQAnTOgGtSjY0LoqT0qapwGcBcyyYF/nqffsR9AxSza2JrW14z1E8D7eAVH31FYGA==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/csskit-linux-x64/-/csskit-linux-x64-0.0.25.tgz",
+      "integrity": "sha512-qDkEhnT9O+74aw0Zt2jsXTUDLiWJ6eRDztu4GZsmvUGPTTDwYtpeCBPkNkHho69w9KajCTtC6mKSYow7rMNNGA==",
       "cpu": [
         "x64"
       ],
@@ -1474,9 +1513,9 @@
       }
     },
     "node_modules/csskit-win32-arm64": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/csskit-win32-arm64/-/csskit-win32-arm64-0.0.24.tgz",
-      "integrity": "sha512-KotV3XmzesWjkwqh3JYfZHg9mc7hCbwcu3/uF++pNaU7qzoEJaqcAUZdPWYdpprVZEg7ICS+udy/oB4iF6wohg==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/csskit-win32-arm64/-/csskit-win32-arm64-0.0.25.tgz",
+      "integrity": "sha512-2alA/S1P/SW1U9WuAKwLEM6KhN755T7bPDgq0mxLI1ry8/FlwClNJcirlmg/7/8Lkvo2DY8g67QdzaSOPKFCag==",
       "cpu": [
         "arm64"
       ],
@@ -1494,9 +1533,9 @@
       }
     },
     "node_modules/csskit-win32-x64": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/csskit-win32-x64/-/csskit-win32-x64-0.0.24.tgz",
-      "integrity": "sha512-9nr/PiBh91gjSuqKBKKHNYf4hl15kRTQw4tJunjy2qvF2Q5cnXnlAwt/3b2fMFZA0TbWCalM7ClVolEEiGCGkA==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/csskit-win32-x64/-/csskit-win32-x64-0.0.25.tgz",
+      "integrity": "sha512-V/gHpd65YuEDWBCCjzJWktFAk9GNHfEKAKsHBPydJfZ1G7IjQ4VF+Wk8WqxeNDGJdUNxHIfuZ1ZfeoPqhc9aJA==",
       "cpu": [
         "x64"
       ],
@@ -1514,13 +1553,13 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-8.0.1.tgz",
-      "integrity": "sha512-oSiOnPQNNYjusTUlYJiE6xvFQG4don3N0QavaoV1BxIsC1zjvxOwikXlR7lG1EVmZNDDaJkHbQx1VRB8kaoMHA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-8.0.2.tgz",
+      "integrity": "sha512-K+a76gA1v0/CsYgcsE95HGGyIuPKxpQSetwSwz4nHEM8fFXqSkzq2JzEXFL8v5+CCjxzVVVhPcTK3Oo8SaF/xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssnano-preset-default": "^8.0.1",
+        "cssnano-preset-default": "^8.0.2",
         "lilconfig": "^3.1.3"
       },
       "engines": {
@@ -1531,64 +1570,64 @@
         "url": "https://opencollective.com/cssnano"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-8.0.1.tgz",
-      "integrity": "sha512-OTdKeYMlvQ8KBgyej5ysktnWJoeyo7rGrVnm+bdpIHGvxhbTGPsOkB+7T1EdTuX00dGlQQb2UEbSPB1OpMXULw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-8.0.2.tgz",
+      "integrity": "sha512-+jQAqIKCqMmBjZs7741XkilU93ITZ/EW8gjAkMmujdCzfDkfjrDBv2VqkSu29Fzeig/0rZ3S9IAwfPLlmXEUfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
-        "cssnano-utils": "^6.0.0",
+        "cssnano-utils": "^6.0.1",
         "postcss-calc": "^10.1.1",
-        "postcss-colormin": "^8.0.0",
-        "postcss-convert-values": "^8.0.0",
-        "postcss-discard-comments": "^8.0.0",
-        "postcss-discard-duplicates": "^8.0.0",
-        "postcss-discard-empty": "^8.0.0",
-        "postcss-discard-overridden": "^8.0.0",
-        "postcss-merge-longhand": "^8.0.0",
-        "postcss-merge-rules": "^8.0.0",
-        "postcss-minify-font-values": "^8.0.0",
-        "postcss-minify-gradients": "^8.0.0",
-        "postcss-minify-params": "^8.0.0",
-        "postcss-minify-selectors": "^8.0.1",
-        "postcss-normalize-charset": "^8.0.0",
-        "postcss-normalize-display-values": "^8.0.0",
-        "postcss-normalize-positions": "^8.0.0",
-        "postcss-normalize-repeat-style": "^8.0.0",
-        "postcss-normalize-string": "^8.0.0",
-        "postcss-normalize-timing-functions": "^8.0.0",
-        "postcss-normalize-unicode": "^8.0.0",
-        "postcss-normalize-url": "^8.0.0",
-        "postcss-normalize-whitespace": "^8.0.0",
-        "postcss-ordered-values": "^8.0.0",
-        "postcss-reduce-initial": "^8.0.0",
-        "postcss-reduce-transforms": "^8.0.0",
-        "postcss-svgo": "^8.0.0",
-        "postcss-unique-selectors": "^8.0.0"
+        "postcss-colormin": "^8.0.1",
+        "postcss-convert-values": "^8.0.1",
+        "postcss-discard-comments": "^8.0.1",
+        "postcss-discard-duplicates": "^8.0.1",
+        "postcss-discard-empty": "^8.0.1",
+        "postcss-discard-overridden": "^8.0.1",
+        "postcss-merge-longhand": "^8.0.1",
+        "postcss-merge-rules": "^8.0.1",
+        "postcss-minify-font-values": "^8.0.1",
+        "postcss-minify-gradients": "^8.0.1",
+        "postcss-minify-params": "^8.0.1",
+        "postcss-minify-selectors": "^8.0.2",
+        "postcss-normalize-charset": "^8.0.1",
+        "postcss-normalize-display-values": "^8.0.1",
+        "postcss-normalize-positions": "^8.0.1",
+        "postcss-normalize-repeat-style": "^8.0.1",
+        "postcss-normalize-string": "^8.0.1",
+        "postcss-normalize-timing-functions": "^8.0.1",
+        "postcss-normalize-unicode": "^8.0.1",
+        "postcss-normalize-url": "^8.0.1",
+        "postcss-normalize-whitespace": "^8.0.1",
+        "postcss-ordered-values": "^8.0.1",
+        "postcss-reduce-initial": "^8.0.1",
+        "postcss-reduce-transforms": "^8.0.1",
+        "postcss-svgo": "^8.0.1",
+        "postcss-unique-selectors": "^8.0.1"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/cssnano-utils": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-6.0.0.tgz",
-      "integrity": "sha512-ztS9W/+uaDn+bkYmDhs+GdMveHJ3CL8IPNHpRqDUQXv5GJOTQAJjV1XUOInr9esLXSabQV1pLRZlJpyUwEqDyQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-6.0.1.tgz",
+      "integrity": "sha512-zk65GIxA8tCjqVk7nTm1mE+ZKxtnxAvU5JSUaBLXbAr3ZF7IOvz3fbPOnEDvZKhnS7GOIitXTS5BgehLzNoc8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/csso": {
@@ -1732,9 +1771,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.355",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
-      "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
+      "version": "1.5.374",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.374.tgz",
+      "integrity": "sha512-HCF5i7izveksHSGqa7mhDh6tr3Uz9Dar2RAjwuh69bw3QGPVObjQIgLwQWeO/Rxp9/r0KdboKy9RbpQDl97fjg==",
       "dev": true,
       "license": "ISC"
     },
@@ -1785,9 +1824,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1798,32 +1837,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -2122,6 +2161,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -2408,20 +2454,6 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/marked": {
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
@@ -2626,11 +2658,14 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -2698,6 +2733,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/picocolors": {
@@ -2782,28 +2827,28 @@
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-8.0.0.tgz",
-      "integrity": "sha512-KKwMmsSgsmdYXqrjQeqL3tnuIFtctiR1GEMHdjNpDpz/TCRkkkok2mMcreK2zVV3l7POWOmAkR2xYHUpRUK1DA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-8.0.1.tgz",
+      "integrity": "sha512-qBY4ABQ6d8/mk5RRZHwMllrZMxeMey3azVY2dZUEk+RgiUC4ARdPR3/AITzNqqKTbvW/3y/MJKinDrzwqn8RDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@colordx/core": "^5.4.3",
         "browserslist": "^4.28.2",
-        "caniuse-api": "^3.0.0",
+        "caniuse-api": "^4.0.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-8.0.0.tgz",
-      "integrity": "sha512-Ohtj3rNZWawTRePv5NCHTy8VJSdJ/G/uKuxcxJreOMichuqcT6uEl2TAnopVeJCJ/c13jaSqg7m63yFLM5zBsA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-8.0.1.tgz",
+      "integrity": "sha512-IdOSIX3BzfMvCc1TAHIha2gfy17xnb5vfML8e2BIKARnFOghksESfaSAB/3CXgyLfMozZAbTRPVQF5dbuKOidw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2814,104 +2859,104 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-discard-comments": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-8.0.0.tgz",
-      "integrity": "sha512-zGpvVLj2sbagEp+BTVETvAfkZdGVA6rALNujDK/WTIjdf1/rQOxOG8BBzkI8UQgnw8SkL6xffAfbtGMHFypadw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-8.0.1.tgz",
+      "integrity": "sha512-FDvzm3tXlEsQBO2XQgnta5ugsAqwBrgWH+j5QgXpegEIDYA0VPnZg2aP7LtmWtC49POskeIhXesFiU/k3NyFHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "postcss-selector-parser": "^7.1.1"
+        "postcss-selector-parser": "^7.1.2"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-discard-duplicates": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-8.0.0.tgz",
-      "integrity": "sha512-zjRyYmNGI3PTipKBBtCgExlmZXQn49KvKoaiNnR2g+iXxeNk7GY5Js2ULtZXPrCYeqjPagrzKIBNcBocvXCR7g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-8.0.1.tgz",
+      "integrity": "sha512-stTDXkI8YkCUfADurQhp03oq5ynsgSx6Qrw5B1swds6oTHtAeOZ9I0SHGK8cY/VpWUsIYFDWMs3IWf9jIEfFvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-discard-empty": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-8.0.0.tgz",
-      "integrity": "sha512-kxPJg6EqahbBvm+l7hpYYCtpsv8dlz7Tv6wJXUXZaeuY0WGS61DxfGdZR4uVB/Cx+yi3iOHQVSqpSHKMFaBg6Q==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-8.0.1.tgz",
+      "integrity": "sha512-Zv4fM1Yfhk71tbt6gfiptbL6jDHi+7apSnaMeaO9n1uET+1embrXQw5m93Zp5x28UyQSuv+AVkFY193jdwZ33w==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-discard-overridden": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-8.0.0.tgz",
-      "integrity": "sha512-sW2OWH3l9p0FmBSVr228uztFseqroZxwgD7SGF0Ks0dRPDttSo3P8FK5ZBLtWBH2A5+chpB0J2fB/T8heKHLBw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-8.0.1.tgz",
+      "integrity": "sha512-ykt4fvrC7yYGzbxKyqBVjDCbsjF/11JgWK8enrdkobRyqqEtb/uDUCbKOGdvrK8X7BrShW8Lv5cCRNbdkNHGkQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-8.0.0.tgz",
-      "integrity": "sha512-YDmAmQ8H+ljfomVpSXvr9NA0GP01fraQJqjWBYoMVGg6rOT+PJLwPyeVo2ekn4WB4ZVSH5ddtK3DTRxbz6CFzg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-8.0.1.tgz",
+      "integrity": "sha512-huTfSYgQ13O81SFvAuOi7GWnO48vvybjj3xF+X3qUoPjzvvaLpJH5DcUqqXcwOEulZUcvaV4s0V9WtWs+IAQPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^8.0.0"
+        "stylehacks": "^8.0.1"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-8.0.0.tgz",
-      "integrity": "sha512-bgstL5mpi41dDpnYGDUcI3M814NWkCMcIWpwDqEHXkHg3BT7b4XRAfNEuwJncZOVn/67kVKvWzhfv/7xyrp2uQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-8.0.1.tgz",
+      "integrity": "sha512-o3rk4UpnPNg469tklYwbR/NtvKc/f/wJiVDTnNQ/EFPw/LeiPOHUCvV1GIBQIZHGrBAYdPjToK6a+ojYprsrxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
-        "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^6.0.0",
-        "postcss-selector-parser": "^7.1.1"
+        "caniuse-api": "^4.0.0",
+        "cssnano-utils": "^6.0.1",
+        "postcss-selector-parser": "^7.1.2"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-minify-font-values": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-8.0.0.tgz",
-      "integrity": "sha512-EnOHQEnSt6oH5NrL1DMFAQuwB2IOimFXTCzc9bKfUeH1jREbqIF5MAK4gQJQOC4mPUwJt4sWifAmNZ1qLu6j3Q==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-8.0.1.tgz",
+      "integrity": "sha512-L8Nzs/PRlBSPrLdY/7rAiU5ZN5800+2J/4LRbfyG8SJnPljmgMaXVmQiCklvRS+yObfVRNtvmk/Ean/eoYcSeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2921,81 +2966,81 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-minify-gradients": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-8.0.0.tgz",
-      "integrity": "sha512-43iAnYIGk0ZjNx5X/rkIcHi6dhmu/vEjY0kqfUfxPuJRO+V7jx8uKIdcnL0dpfNoC5J9TSh3EtzLWbq0gpqnWA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-8.0.1.tgz",
+      "integrity": "sha512-qf+4s/hZMqTwpWN2teqf6+1yvR/SZK5HgHqXYuACeJXV7ABe7AXtBEomgxagUzcN4bSnmqBh5vnIml0dYqykYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@colordx/core": "^5.4.3",
-        "cssnano-utils": "^6.0.0",
+        "cssnano-utils": "^6.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-8.0.0.tgz",
-      "integrity": "sha512-z7w4QO7G55l4vMUK1Lmx03GW7iyRLgf2V5Dz/7ioSPLnXRjeD+b7m0XfAXUGrbBYYrJ6bXPk+3LoX5u4JfAcSg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-8.0.1.tgz",
+      "integrity": "sha512-L0h3H59deFfFg0wQN1NVaS/8E/LfGvaMuZKGO7siwlG995zo3OshtQyRkqKdVqcBwAORBvZ1nDZrKPLRapYkQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
-        "cssnano-utils": "^6.0.0",
+        "cssnano-utils": "^6.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-minify-selectors": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-8.0.1.tgz",
-      "integrity": "sha512-c31D46811kTkQDxV1KTTow79axX6gj/01AY5G7cGZg3s31KvAwP13jEFXGAzQbJ7NvOFV1pRqEia6nrAdHU7qg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-8.0.2.tgz",
+      "integrity": "sha512-3icdxc/zght5UAizdwqZBDE2KOWHf1jMQCxET6iLACeNlRxfTPyXS0/COpGk8CQ2cECyaEKTRUd/i/k8Gxmz4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.1",
-        "caniuse-api": "^3.0.0",
+        "caniuse-api": "^4.0.0",
         "cssesc": "^3.0.0",
-        "postcss-selector-parser": "^7.1.1"
+        "postcss-selector-parser": "^7.1.2"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-normalize-charset": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-8.0.0.tgz",
-      "integrity": "sha512-s88FUNDSUD8m0wBYvTQQcubVts6zhXwBU8zCD4vkRKiecd0v8cOjHVIF9r/i+5xzS/WG3f98qq4XsOM0JqvfLA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-8.0.1.tgz",
+      "integrity": "sha512-xzqr36F8UeIZOvOHsf3aul+RVJCADvSwuwpMLgizqKjisHZpBfztgW0XFLBfJvz9pJgaStaOXAtGb0zLqT6B0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-normalize-display-values": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-8.0.0.tgz",
-      "integrity": "sha512-gG2nBxD27fiw6Luinb1QYKdM/Co5GornRJgSD+JTwNH4PGKxImP0qyruDDav49aHUPLY3qrL3qN3LvybO7IzxQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-8.0.1.tgz",
+      "integrity": "sha512-ZDWOijOK1FFMlpgiQCUO9fCNKd7HJ9L7z9HWEq4iyubnUFWzdTSwm/LcrMbNW6iZ1oAtqeLYA0WA3xHszOI08g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3005,13 +3050,13 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-normalize-positions": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-8.0.0.tgz",
-      "integrity": "sha512-t/wGqpehS20Ke7kc4QAsWpH+AJjUdMK/V5qV2RhrXkj8hO/fT1t1MJ8NL7sedWYk7ZqC7eISEJQonW5j0tU1MQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-8.0.1.tgz",
+      "integrity": "sha512-uuivan2poSqbE48ST4do20dGaFUeXey9/H8rhHzoyVHB2I6BmkoVLZ/C9+BRjUlpaAFYVOoDY7epkiidzaYbvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3021,13 +3066,13 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-8.0.0.tgz",
-      "integrity": "sha512-3ebOmGdCYKrBYyGKc1xhj0unEnW7beZpVU7JohVeGl7mTxR+7T6egpaawTWAVsB0pEIhcsbJVOjPKCJSoRO6Zg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-8.0.1.tgz",
+      "integrity": "sha512-q2hq5fmKxk29K6DjKA3nZ17Q2dtjhLYFNmFweKALmooUqx6UWAHF1bBoWTu/EqlJ88josb82A/J0Atj9LJUmpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3037,13 +3082,13 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-normalize-string": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-8.0.0.tgz",
-      "integrity": "sha512-TvWCGZ/e04Tv31uJvOUtbexkfgUnqmQ3M2P5DkAaVzvOj+BvTkG2QjpA5Y71SL1SPxJcj4M23fNh+RDVCmG8kA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-8.0.1.tgz",
+      "integrity": "sha512-+Wf+kQJhm1WgSGEAuUaswE9rdpR9QbrKRVemcVHs6rhOoOTVIdAbgaicftfYA6vLM346P8onRzkEVbFN29ktKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3053,13 +3098,13 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-normalize-timing-functions": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-8.0.0.tgz",
-      "integrity": "sha512-uEfaXst5Xgqxv7geYUuz6vs9mn88K2NPY2RoIzM3BMmSjsdTSeppV9x2qIgrxsisdbSqF6IVhzI2occcte3hTA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-8.0.1.tgz",
+      "integrity": "sha512-W8/tvwRlm3T+yjGkg0IRTF4bvHj0vILYr/LOogCrJKHz2ey2HFRwfsAA8Bk9N4BGR7z7WmmDu/KzzwhJ6FoGPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3069,13 +3114,13 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-8.0.0.tgz",
-      "integrity": "sha512-+WYngZaChEeTHZmWhmKtnJ4gTzWdINEaFcgWBnu6WdVu8Ftim8OBTcw768DuCC/3Aax9bZ9WkwrLGHym2Lzf+A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-8.0.1.tgz",
+      "integrity": "sha512-Ad0YHNRBp4WHEOYUM/4wL/8MoL2fimEF8se/0q+Rt/owMzYpbxsypC1P8fN/oluwoRmRKdNVX7X2oycEobPWcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3086,13 +3131,13 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-normalize-url": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-8.0.0.tgz",
-      "integrity": "sha512-4Mz9hZHn/QIB+YtFqTXrDmE2193GYxGb3F8uMfLvMicaEXCCUlDIJ658gFFJbqEGl9FYzwPtRiuNgbwlO9kkBg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-8.0.1.tgz",
+      "integrity": "sha512-tkYcip6pCDY806xuxpJYqMW2M3/623jzGFJmz3m5Us47q8P28+gbRZxaea3Rr/CmwwLUiVlh+BTGYwQ6gvaP8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3102,13 +3147,13 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-normalize-whitespace": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-8.0.0.tgz",
-      "integrity": "sha512-V1f8tYnwIP5tscOXQFTKK8Y5EJ+R2GMpFJ6FjzwoKoQnhbqQy3IeSrDjJJb8JjVos8ut6Osi80Zybpayv/XjIQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-8.0.1.tgz",
+      "integrity": "sha512-XzORadNfSrKWDZZpgAEHPKINKx8r9r9RIfE9c70g/HThdpbmPHhDYCodHSVESDxmKeySAYw1p4liuBCf7j6LyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3118,47 +3163,47 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-ordered-values": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-8.0.0.tgz",
-      "integrity": "sha512-Dg9+itb6lmD0bxqhQyHCtXAwYRh0wUrx6Mp4/BNXgkLoJmdYMmWi+V+Pypw79Q6iQhxA8KFMHqLBITQJV2gKMA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-8.0.1.tgz",
+      "integrity": "sha512-OLXq5lR1yk3KWQ1FPK6aWjFFdktHE9f9kb8cnt4LmIw7w30DnzgD9+sOVYJc5HenkWCX8i1MJhhFwmqc/GYqLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssnano-utils": "^6.0.0",
+        "cssnano-utils": "^6.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-8.0.0.tgz",
-      "integrity": "sha512-DChcE9d528AKrlpCTHjhsAiOsWCk4H9ApHPS1QqRT3praObWTiWyn6W1UddGpc46K9LQnHwUu4YwaPUukGtXVA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-8.0.1.tgz",
+      "integrity": "sha512-+aQsR6+61KRoIfcFNLP3v9RM7+0iYOTtPnjl1wr6JqMW1zx6S+t2ktHRefXwacFdHIDj5+ETG0KY7K3+SGQ4Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
-        "caniuse-api": "^3.0.0"
+        "caniuse-api": "^4.0.0"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-reduce-transforms": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-8.0.0.tgz",
-      "integrity": "sha512-cLZT0som7vvumQT9XQCnSKOSnRinNQZd1Hm+J723Ney13E8CIydDhw6JwzsjPtgnYThTqn9Q45906gz6wxaAsw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-8.0.1.tgz",
+      "integrity": "sha512-x71slHVykiFi5RuKEXM0wgYpY2PngC78x6R8TnZhHF3lhqt+u/w3MGwYLX+2t5O87ssRiMfEAhQH+3J4QwVzCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3168,13 +3213,13 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3186,9 +3231,9 @@
       }
     },
     "node_modules/postcss-svgo": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-8.0.0.tgz",
-      "integrity": "sha512-Q2fMSYEiNE1ioDc/3sxvI24NdgA/MJno2XLNpOxgv8aCcJbym8mZY10/lDY5+AWCIc3Aiqzy2Wcp9/zaIXBZgQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-8.0.1.tgz",
+      "integrity": "sha512-HpnvWii7W0/FPrsejJa6ZTi0kNtTJP/Iba7CUMPX0xPV6QpnndOp+SDP74tFtgjA2cYKYNWJPOlmLXMsvi/9yA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3199,23 +3244,23 @@
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-unique-selectors": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-8.0.0.tgz",
-      "integrity": "sha512-iObuolUX+ITJfMU2QQFQdh31JgSjNLPNjVs6YGAqBHvOvAWXMMNget6donQl83aQaeS32i5XeKZURUW/WBxIUw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-8.0.1.tgz",
+      "integrity": "sha512-+xvKI5+/Cl8yYQwxDV39Uhuc4WV951xngFvPPjiPj2NIbIfm6vbbRTXblyw0FioLkIoGlw+7qUcY1h2YhaZYgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "postcss-selector-parser": "^7.1.1"
+        "postcss-selector-parser": "^7.1.2"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -3338,9 +3383,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.100.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
-      "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
+      "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3374,6 +3419,29 @@
       "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/shiki": {
       "version": "4.2.0",
@@ -3518,20 +3586,20 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-8.0.0.tgz",
-      "integrity": "sha512-sWyjaJvBqHoVKYPbQ8JRvrGSPaYWtWrJsU+fGVtwKB1GE1rRPu3rC7T6UCuXLoL00Dwb+tsHe2T904r8Vnsx8w==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-8.0.1.tgz",
+      "integrity": "sha512-Gv095oTD0N+BdJALNFDsxZpETHZLTxbOl5RyIO7y6VAE6sR3z0MnV3Nix7N0IATNldNTrkvSASp2KR1Yt526HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
-        "postcss-selector-parser": "^7.1.1"
+        "postcss-selector-parser": "^7.1.2"
       },
       "engines": {
         "node": "^22.11.0 || ^24.11.0 || >=26.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.14"
+        "postcss": "^8.5.15"
       }
     },
     "node_modules/supports-color": {
@@ -3777,6 +3845,22 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -5,30 +5,30 @@
   "description": "Correctness tests for CSS minifiers",
   "scripts": {
     "start": "http-server",
-    "fmt": "npx prettier --write .",
-    "test": "node ./run-tests.js",
-    "test:debug": "DEBUG=true node ./run-tests.js",
+    "test": "cross-env NO_COLOR=1 node ./run-tests.js",
+    "test:debug": "cross-env DEBUG=true node ./run-tests.js",
     "new-test": "bash -c 'd=tests/$1/$(printf \"%04d\" $(($(ls tests/$1 2>/dev/null|sort -n|tail -1)+1))) && mkdir -p $d && touch $d/source.css $d/expected.css $d/README.md && echo \"Created $d\" && ${EDITOR:-vim} $d/source.css $d/expected.css $d/README.md' --"
   },
   "devDependencies": {
     "@thejaredwilcurt/csslop": "^0.0.5",
     "clean-css": "^5.3.3",
-    "csskit": "^0.0.24",
-    "cssnano": "^8.0.1",
+    "cross-env": "^10.1.0",
+    "csskit": "^0.0.25",
+    "cssnano": "^8.0.2",
     "csso": "^5.0.5",
-    "esbuild": "^0.28.0",
+    "esbuild": "^0.28.1",
     "http-server": "^14.1.1",
     "lightningcss": "^1.30.0",
     "marked": "^18.0.5",
     "postcss": "^8.5.15",
     "pretty-ms": "^9.3.0",
     "real-world-css-libraries": "^1.0.2",
-    "sass": "^1.100.0",
+    "sass": "^1.101.0",
     "shiki": "^4.2.0"
   },
   "allowScripts": {
     "@parcel/watcher@2.5.6": true,
-    "esbuild@0.28.0": true
+    "esbuild@0.28.1": true
   },
   "devEngines": {
     "runtime": {


### PR DESCRIPTION
This is a smaller portion of #87 to help reduce the total amount of changes introduced in that PR.

* Updates all dependencies. (Closes #86)
  * `csskit` now passes all real world tests without errors
  * Updated allowScripts.
  * Ran `npm audit fix`.
* Added `NO_COLOR` environment variable and set Sass to use `alertColor: false`, this removes all CLI ASCII color codes from the error message outputs, so they can be shown correctly on the website.
  * Before:
    ```
    "&" may only used at the beginning of a compound selector.
    [34m  ╷[0m
    [34m3 │[0m   &[31m[0m& {
    [34m  │[0m [31m   ^[0m
    [34m  ╵[0m
      - 3:4  root stylesheet
    ```
  * After:
    ```
    "&" may only used at the beginning of a compound selector.
      ╷
    3 │   && {
      │    ^
      ╵
      - 3:4  root stylesheet
    ```
* I tried caching the `bin` lookup in `/lib/minifiers/csskit.js` to make minifier calls to it faster. It did make it faster, but only barely. I thought that the `execSync` call to get the version on every minification would be adding a lot of overhead, but it really wasn't that much. I still suspect there is some trick to make it run much faster, but that may need to occur upstream in the `csskit` repo.
* All minification outputs are trimmed of starting/trailing whitepace. This resulted in Sass passing one new test (`counter-style/0001`). It also resulted in a 1 byte improvement on a bunch of the realworld tests for csskit, esbuild, and Sass. Though I prefer a new line at the end of my outputted `*.min.css` files, not all of the minifiers do this, so this is a more accurate comparison of them.
* New minifier helper to support title case, will be used in select parts of the markup for presentation (#87).