### PR TITLE
Break up and organize Real World test logic

### DIFF
--- a/lib/createWebsite/makeRealWorldTable.js
+++ b/lib/createWebsite/makeRealWorldTable.js
@@ -1,72 +1,12 @@
-import { writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-
 import { minifiers } from '../loaders/loadAllMinifiers.js';
-import { loadAllRealWorldTests } from '../loaders/loadAllRealWorldTests.js';
+import { minifyAllRealWorldTests } from '../runners/realWorld.js';
 import { ERROR } from '../constants.js';
 import {
-  durationNsToMs,
   formatMs,
   html
 } from '../helpers.js';
-import { minify } from '../minify.js';
 
 const __dirname = import.meta.dirname;
-
-const minifyAllRealWorldTests = async function () {
-  const startAll = process.hrtime.bigint();
-  const libraries = loadAllRealWorldTests();
-
-  for (const minifier of minifiers) {
-    for (const library of libraries) {
-      library.results = library.results || {};
-      library.duration = library.duration || {};
-      let result = '';
-      let error = false;
-      const start = process.hrtime.bigint();
-      try {
-        result = await minify(minifier, library.source);
-      } catch {
-        error = true;
-      }
-      const end = process.hrtime.bigint();
-      library.duration[minifier] = durationNsToMs(start, end);
-      if (error) {
-        library.results[minifier] = ERROR;
-      } else {
-        library.results[minifier] = result.length;
-      }
-    }
-  }
-  const jsonLibraries = [];
-  for (const library of libraries) {
-    jsonLibraries.push({
-      name: library.name,
-      version: library.version,
-      size: library.source.length,
-      results: {
-        ...library.results
-      }
-    });
-  }
-
-  const oututFile = join(__dirname, '..', '..', 'data', 'real-world-results.json');
-  const output = JSON.stringify(jsonLibraries, null, 2);
-  writeFileSync(oututFile, output + '\n');
-
-  const endAll = process.hrtime.bigint();
-  const duration = durationNsToMs(startAll, endAll);
-
-  console.log([
-    libraries.length,
-    'real world libraries minified by',
-    minifiers.length,
-    'minifiers in',
-    formatMs(duration) + '.'
-  ].join(' '));
-
-  return libraries;
-};
 
 const makeSizeTable = function (results) {
   const makeHeaders = function () {
@@ -351,7 +291,7 @@ const makeSizeTable = function (results) {
           ${allTotals}
         </tr>
         <tr>
-          <th>Total Percents</th>
+          <th>Percent Reduction</th>
           ${allPercents}
         </tr>
         <tr>

--- a/lib/reporters/README.md
+++ b/lib/reporters/README.md
@@ -1,0 +1,3 @@
+This folder is for logic related to generating reports or logging out summaries after tests have ran.
+
+It is not for logic related to running minifiers, or creating the website.

--- a/lib/reporters/realWorld.js
+++ b/lib/reporters/realWorld.js
@@ -1,0 +1,56 @@
+/**
+ * @file Logic related to reporting or storing the results of real-world test runs.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  durationNsToMs,
+  formatMs
+} from '../helpers.js';
+
+const __dirname = import.meta.dirname;
+
+/**
+ * Updates the /data/real-world-results.json file with the results from the most
+ * recent running of all minifiers against the real-world-css-libraries repo.
+ *
+ * @param {Object[]} libraries  List of all real-world CSS libraries that were minified
+ */
+export const updateRealWorldCachedResults = function (libraries) {
+  const jsonLibraries = [];
+  for (const library of libraries) {
+    jsonLibraries.push({
+      name: library.name,
+      version: library.version,
+      size: library.source.length,
+      results: {
+        ...library.results
+      }
+    });
+  }
+
+  const oututFile = join(__dirname, '..', '..', 'data', 'real-world-results.json');
+  const output = JSON.stringify(jsonLibraries, null, 2);
+  writeFileSync(oututFile, output + '\n');
+};
+
+/**
+ * Logs out a summary of information about the real-world tests after they run.
+ *
+ * @param {Object[]} libraries  List of all real-world CSS libraries that were minified
+ * @param {string[]} minifiers  List of all minifier names
+ * @param {BigInt}   startAll   Timestamp prior to running all realworld tests
+ */
+export const logRealWorldOutcome = function (libraries, minifiers, startAll) {
+  const endAll = process.hrtime.bigint();
+  const duration = durationNsToMs(startAll, endAll);
+  console.log([
+    libraries.length,
+    'real world libraries minified by',
+    minifiers.length,
+    'minifiers in',
+    formatMs(duration) + '.'
+  ].join(' '));
+};

--- a/lib/runners/README.md
+++ b/lib/runners/README.md
@@ -1,0 +1,3 @@
+Logic in this folder is focused on running minifiers against various test strings of CSS.
+
+It is not for generating the website, logging out information to the console, or creating reports or summaries.

--- a/lib/runners/realWorld.js
+++ b/lib/runners/realWorld.js
@@ -1,0 +1,41 @@
+import { minifiers } from '../loaders/loadAllMinifiers.js';
+import { loadAllRealWorldTests } from '../loaders/loadAllRealWorldTests.js';
+import {
+  logRealWorldOutcome,
+  updateRealWorldCachedResults
+} from '../reporters/realWorld.js';
+import { ERROR } from '../constants.js';
+import { durationNsToMs } from '../helpers.js';
+import { minify } from '../minify.js';
+
+export const minifyAllRealWorldTests = async function () {
+  const startAll = process.hrtime.bigint();
+  const libraries = loadAllRealWorldTests();
+
+  for (const minifier of minifiers) {
+    for (const library of libraries) {
+      library.results = library.results || {};
+      library.duration = library.duration || {};
+      let result = '';
+      let error = false;
+      const start = process.hrtime.bigint();
+      try {
+        result = await minify(minifier, library.source);
+        result = result.trim();
+      } catch {
+        error = true;
+      }
+      const end = process.hrtime.bigint();
+      library.duration[minifier] = durationNsToMs(start, end);
+      if (error) {
+        library.results[minifier] = ERROR;
+      } else {
+        library.results[minifier] = result.length;
+      }
+    }
+  }
+
+  updateRealWorldCachedResults(libraries);
+  logRealWorldOutcome(libraries, minifiers, startAll);
+  return libraries;
+};


### PR DESCRIPTION
This is a portion of #87.

Breaks up the logic related to Real World library testing.

* `/lib/runners` folder is for logic that runs the minifiers
* `/lib/reporters` folder is for logic that generates reports, either as `/data/*.json` files or as CLI output summaries during `npm t`.
