### PR TITLE
Move loading logic into loaders folder

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,6 +2,11 @@
  * @file Storage for constants.
  */
 
+import { join } from 'node:path';
+
+const __dirname = import.meta.dirname;
+
 export const CHECKMARK = '&#10003;'; // ✓
 export const CROSS_MARK = '&#10007;'; // ✗
 export const ERROR = 'ERROR';
+export const HISTORY_PATH = join(__dirname, '..', 'data', 'results-history.json');

--- a/lib/history.js
+++ b/lib/history.js
@@ -1,20 +1,8 @@
 import fs from 'node:fs/promises';
-import path from 'node:path';
 
 import { minifiers } from './loaders/loadAllMinifiers.js';
-
-const __dirname = import.meta.dirname;
-
-const HISTORY_PATH = path.join(__dirname, '..', 'data', 'results-history.json');
-
-export async function readHistory () {
-  try {
-    const raw = await fs.readFile(HISTORY_PATH, 'utf-8');
-    return JSON.parse(raw);
-  } catch {
-    return [];
-  }
-}
+import { readHistory } from './loaders/loadResultsHistory.js';
+import { HISTORY_PATH } from './constants.js';
 
 export async function appendHistory (allTests, results, versions) {
   const history = await readHistory();

--- a/lib/loaders/loadResultsHistory.js
+++ b/lib/loaders/loadResultsHistory.js
@@ -1,0 +1,20 @@
+/**
+ * @file Loads in the `/data/results-history.json` file.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { HISTORY_PATH } from '../constants.js';
+
+/**
+ * Reads and parses the `/data/results-history.json` file.
+ *
+ * @return {object} The parsed JSON object from the file
+ */
+export async function readHistory () {
+  try {
+    return JSON.parse(readFileSync(HISTORY_PATH));
+  } catch {
+    return [];
+  }
+}

--- a/lib/loaders/loadVersions.js
+++ b/lib/loaders/loadVersions.js
@@ -7,6 +7,8 @@ import { resolve } from 'node:path';
 
 import { minifiers } from './loadAllMinifiers.js';
 
+const __dirname = import.meta.dirname;
+
 /**
  * Gets the version numbers for all minifiers by
  * looking in the node_modules folder.
@@ -21,7 +23,8 @@ export function getVersions () {
   };
   for (let minifierName of minifiers) {
     const pathParts = [
-      import.meta.dirminifierName,
+      __dirname,
+      '..',
       '..',
       'node_modules'
     ];

--- a/lib/loaders/loadVersions.js
+++ b/lib/loaders/loadVersions.js
@@ -1,0 +1,42 @@
+/**
+ * @file Loads in the minifier version numbers from node_modules.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { minifiers } from './loadAllMinifiers.js';
+
+/**
+ * Gets the version numbers for all minifiers by
+ * looking in the node_modules folder.
+ *
+ * @param  {string[]} names  Names of all minifiers to check
+ * @return {object}          Keys are minifier names, values are version strings
+ */
+export function getVersions () {
+  const versions = {};
+  const scopedPackages = {
+    csslop: '@thejaredwilcurt'
+  };
+  for (let minifierName of minifiers) {
+    const pathParts = [
+      import.meta.dirminifierName,
+      '..',
+      'node_modules'
+    ];
+    if (scopedPackages[minifierName]) {
+      pathParts.push(scopedPackages[minifierName]);
+    }
+    pathParts.push(minifierName);
+    pathParts.push('package.json');
+    try {
+      const manifestPath = resolve(...pathParts);
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+      versions[minifierName] = manifest.version;
+    } catch {
+      versions[minifierName] = null;
+    }
+  }
+  return versions;
+}

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -1,38 +1,8 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
-import { minifiers, registry } from './loaders/loadAllMinifiers.js';
+import { registry } from './loaders/loadAllMinifiers.js';
 
 export async function minify (name, source) {
   const fn = registry.get(name);
   if (!fn) throw new Error(`Unknown minifier: ${name}`);
   const output = await fn(source);
   return output.trim();
-}
-
-export function getVersions (names = minifiers) {
-  const versions = {};
-  const scopedPackages = {
-    csslop: '@thejaredwilcurt'
-  };
-  for (let name of names) {
-    const pathParts = [
-      import.meta.dirname,
-      '..',
-      'node_modules'
-    ];
-    if (scopedPackages[name]) {
-      pathParts.push(scopedPackages[name]);
-    }
-    pathParts.push(name);
-    pathParts.push('package.json');
-    try {
-      const pkgPath = path.resolve(...pathParts);
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-      versions[name] = pkg.version;
-    } catch {
-      versions[name] = null;
-    }
-  }
-  return versions;
 }

--- a/lib/reporters/allTests.js
+++ b/lib/reporters/allTests.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { minifiers } from '../loaders/loadAllMinifiers.js';
 import { appendHistory } from '../history.js';
-import { getVersions } from '../loaders/loadVersions.js.js';
+import { getVersions } from '../loaders/loadVersions.js';
 import { resultsAsHTML } from '../results-as-html.js';
 
 const __dirname = import.meta.dirname;

--- a/lib/reporters/allTests.js
+++ b/lib/reporters/allTests.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { minifiers } from '../loaders/loadAllMinifiers.js';
 import { appendHistory } from '../history.js';
-import { getVersions } from '../minify.js';
+import { getVersions } from '../loaders/loadVersions.js.js';
 import { resultsAsHTML } from '../results-as-html.js';
 
 const __dirname = import.meta.dirname;
@@ -153,7 +153,7 @@ export const reportTestResults = async function (allTests, results) {
     }
   }
 
-  const versions = getVersions(minifiers);
+  const versions = getVersions();
   const history = await appendHistory(allTests, results, versions);
   await resultsAsHTML(allTests, results, versions, history, 'index.html');
   console.log('HTML report written to index.html');


### PR DESCRIPTION
Moves `getVersions` and `readHistory` into loaders, since they both deal with loading data from disk.

* [x] Ran `npm t && npm start` locally