### PR TITLE
Group minifier data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,12 +172,16 @@ In `lib/loaders/loadAllMinifiers.js`:
    for version lookups and display).
 
 ```js
-import myMinifier from "../minifiers/my-minifier.js";
+import myMinifier from '../minifiers/my-minifier.js';
 
-export const registry = new Map([
-  // ... existing entries ...
-  ["my-minifier", myMinifier],
-]);
+export const registry = Object.freeze({
+  'my-minifier': {
+    title: 'My Minifier',
+    url: 'https://my-minifier.github.io/playground',
+    minify: myMinifier
+  },
+  // ...other existing minifiers
+});
 ```
 
 ### 4. Run the tests

--- a/data/real-world-results.json
+++ b/data/real-world-results.json
@@ -231,7 +231,7 @@
     "results": {
       "clean-css": 88176,
       "csskit": 89186,
-      "csslop": 85031,
+      "csslop": 85030,
       "cssnano": 87767,
       "csso": 87717,
       "esbuild": 88571,
@@ -411,7 +411,7 @@
     "results": {
       "clean-css": 13671,
       "csskit": 15118,
-      "csslop": 11560,
+      "csslop": 11554,
       "cssnano": 11274,
       "csso": 25701,
       "esbuild": 14791,
@@ -441,7 +441,7 @@
     "results": {
       "clean-css": 183378,
       "csskit": 183234,
-      "csslop": 181488,
+      "csslop": 181476,
       "cssnano": 182206,
       "csso": 183048,
       "esbuild": 184401,
@@ -516,7 +516,7 @@
     "results": {
       "clean-css": 8999,
       "csskit": 20242,
-      "csslop": 19856,
+      "csslop": 19854,
       "cssnano": 16294,
       "csso": 6676,
       "esbuild": 20293,
@@ -591,7 +591,7 @@
     "results": {
       "clean-css": 26284,
       "csskit": 26428,
-      "csslop": 13225,
+      "csslop": 13200,
       "cssnano": 13895,
       "csso": 25803,
       "esbuild": 26193,
@@ -711,7 +711,7 @@
     "results": {
       "clean-css": 50058,
       "csskit": 49587,
-      "csslop": 42261,
+      "csslop": 42257,
       "cssnano": 48960,
       "csso": 49814,
       "esbuild": 49569,
@@ -1221,7 +1221,7 @@
     "results": {
       "clean-css": 13405,
       "csskit": 12858,
-      "csslop": 7150,
+      "csslop": 7149,
       "cssnano": 7562,
       "csso": 13390,
       "esbuild": 13071,
@@ -1401,7 +1401,7 @@
     "results": {
       "clean-css": 252550,
       "csskit": 258149,
-      "csslop": 230059,
+      "csslop": 230047,
       "cssnano": 219931,
       "csso": 252766,
       "esbuild": 253587,
@@ -1446,7 +1446,7 @@
     "results": {
       "clean-css": 14945,
       "csskit": 17294,
-      "csslop": 10013,
+      "csslop": 9994,
       "cssnano": 10622,
       "csso": 17215,
       "esbuild": 17473,
@@ -1851,7 +1851,7 @@
     "results": {
       "clean-css": 86572,
       "csskit": 86101,
-      "csslop": 81681,
+      "csslop": 81679,
       "cssnano": 83229,
       "csso": 87845,
       "esbuild": 87252,
@@ -1926,7 +1926,7 @@
     "results": {
       "clean-css": 7391,
       "csskit": 7340,
-      "csslop": 6650,
+      "csslop": 6646,
       "cssnano": 7242,
       "csso": 7361,
       "esbuild": 7417,
@@ -2481,7 +2481,7 @@
     "results": {
       "clean-css": 14549,
       "csskit": 14680,
-      "csslop": 12839,
+      "csslop": 12837,
       "cssnano": 14220,
       "csso": 13808,
       "esbuild": 14537,
@@ -2856,7 +2856,7 @@
     "results": {
       "clean-css": 16445,
       "csskit": 16710,
-      "csslop": 14639,
+      "csslop": 14631,
       "cssnano": 14954,
       "csso": 16468,
       "esbuild": 14836,

--- a/data/results-history.json
+++ b/data/results-history.json
@@ -1,5 +1,51 @@
 [
   {
+    "date": "2026-07-16T14:11:40.394Z",
+    "testCount": 455,
+    "minifiers": {
+      "clean-css": {
+        "version": "5.3.3",
+        "pass": 165,
+        "total": 455
+      },
+      "csskit": {
+        "version": "0.0.27",
+        "pass": 176,
+        "total": 455
+      },
+      "csslop": {
+        "version": "0.0.13",
+        "pass": 455,
+        "total": 455
+      },
+      "cssnano": {
+        "version": "8.0.2",
+        "pass": 223,
+        "total": 455
+      },
+      "csso": {
+        "version": "5.0.5",
+        "pass": 165,
+        "total": 455
+      },
+      "esbuild": {
+        "version": "0.28.1",
+        "pass": 197,
+        "total": 455
+      },
+      "lightningcss": {
+        "version": "1.32.0",
+        "pass": 296,
+        "total": 455
+      },
+      "sass": {
+        "version": "1.101.0",
+        "pass": 131,
+        "total": 455
+      }
+    }
+  },
+  {
     "date": "2026-07-06T15:24:43.847Z",
     "testCount": 455,
     "minifiers": {

--- a/lib/createWebsite/makeRealWorldTable.js
+++ b/lib/createWebsite/makeRealWorldTable.js
@@ -341,7 +341,7 @@ const makeSizeTable = function (results) {
  * @return {string} The markup for the table
  */
 export const makeRealWorldTable = async function () {
-  console.log('Started minifying real world CSS files.');
+  console.log('Started minifying real world CSS files (may take a minute).');
   const results = await minifyAllRealWorldTests();
   const realWorldMarkup = html`
     <div>

--- a/lib/loaders/loadAllMinifiers.js
+++ b/lib/loaders/loadAllMinifiers.js
@@ -13,28 +13,76 @@ import lightningcss from '../minifiers/lightningcss.js';
 import sass from '../minifiers/sass.js';
 
 /**
+ * @callback                   MINIFY
+ * @param    {string}          inputCSS  The input CSS to be minified
+ * @return   {Promise<string>}           The minified CSS output
+ */
+
+/**
+ * @typedef  {object} ENTRY
+ * @property {string} title   The minifier name's official orthographie
+ * @property {string} url     The URL to the minifier's online playground/site
+ * @property {MINIFY} minify  The async minification function for benchmarking
+ */
+
+/* eslint-disable-next-line jsdoc/check-types */
+/** @typedef {object<string, ENTRY>} REGISTRY */
+
+/**
  * The key is the npm package name, used for version lookups and displaying in
  * reports.
  *
- * @type {Map}
+ * @type {REGISTRY}
  */
-export const registry = new Map([
-  ['clean-css', cleanCss],
-  ['csskit', csskit],
-  ['csslop', csslop],
-  ['cssnano', cssnano],
-  ['csso', csso],
-  ['esbuild', esbuild],
-  ['lightningcss', lightningcss],
-  ['sass', sass]
-]);
+export const registry = Object.freeze({
+  'clean-css': {
+    title: 'CleanCSS',
+    url: 'https://clean-css.github.io',
+    minify: cleanCss
+  },
+  csskit: {
+    title: 'csskit',
+    url: 'https://csskit.rs/playground',
+    minify: csskit
+  },
+  csslop: {
+    title: 'CSSLOP',
+    url: 'https://thejaredwilcurt.com/csslop',
+    minify: csslop
+  },
+  cssnano: {
+    title: 'cssnano',
+    url: 'https://cssnano.github.io/cssnano/playground',
+    minify: cssnano
+  },
+  csso: {
+    title: 'CSS Optimizer',
+    url: 'https://css.github.io/csso/csso.html',
+    minify: csso
+  },
+  esbuild: {
+    title: 'esbuild',
+    url: 'https://esbuild.github.io/try/#YgAwLjI4LjEAZmlsZS5jc3MgLS1taW5pZnkAAGZpbGUuY3NzAA',
+    minify: esbuild
+  },
+  lightningcss: {
+    title: 'Lightning CSS',
+    url: 'https://lightningcss.dev/playground',
+    minify: lightningcss
+  },
+  sass: {
+    title: 'Sass',
+    url: 'https://sass-lang.com/playground/#eJwzNAAAAJQAYg==',
+    minify: sass
+  }
+});
 
 /**
  * Names of all the minifier tools.
  *
  * @type {string[]}  ['clean-css', 'csskit', ...]
  */
-export const minifiers = [...registry.keys()];
+export const minifiers = Object.keys(registry);
 
 /**
  * Returns a minifier name's official orthographie including
@@ -44,17 +92,7 @@ export const minifiers = [...registry.keys()];
  * @return {string}               The official title-cased version
  */
 export const getMinifierTitle = function (minifierName) {
-  const minifierTitleNameMap = {
-    'clean-css': 'CleanCSS',
-    csskit: 'csskit',
-    csslop: 'CSSLOP',
-    cssnano: 'cssnano',
-    csso: 'CSS Optimizer',
-    esbuild: 'esbuild',
-    lightningcss: 'Lightning CSS',
-    sass: 'Sass'
-  };
-  return minifierTitleNameMap[minifierName] || minifierName;
+  return registry[minifierName]?.title || minifierName;
 };
 
 /**
@@ -65,18 +103,8 @@ export const getMinifierTitle = function (minifierName) {
  * @return {string}               The URL to the minifiers website/playground
  */
 export const getMinifierUrl = function (minifierName) {
-  const minifierUrlMap = {
-    'clean-css': 'https://clean-css.github.io',
-    csskit: 'https://csskit.rs/playground',
-    csslop: 'https://thejaredwilcurt.com/csslop',
-    cssnano: 'https://cssnano.github.io/cssnano/playground',
-    csso: 'https://css.github.io/csso/csso.html',
-    esbuild: 'https://esbuild.github.io/try/#YgAwLjI4LjEAZmlsZS5jc3MgLS1taW5pZnkAAGZpbGUuY3NzAA',
-    lightningcss: 'https://lightningcss.dev/playground',
-    sass: 'https://sass-lang.com/playground/#eJwzNAAAAJQAYg=='
-  };
-  if (!minifierUrlMap[minifierName]) {
+  if (!registry[minifierName]?.url) {
     throw 'MISSING ' + minifierName + ' FROM LIST IN getMinifierUrl FUNCTION';
   }
-  return minifierUrlMap[minifierName];
+  return registry[minifierName].url;
 };

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -8,14 +8,14 @@ import { registry } from './loaders/loadAllMinifiers.js';
  * Runs the minification function of the given named minifier with the given
  * CSS source string. Ensures all outputs are trimmed for accurate comparisons.
  *
- * @param  {string} name    Name of the minifier (csso, sass, etc)
- * @param  {string} source  Any string of CSS to be minified
- * @return {string}         The minified output
+ * @param  {string} minifierName  Name of the minifier (csso, sass, etc)
+ * @param  {string} source        Any string of CSS to be minified
+ * @return {string}               The minified output
  */
-export async function minify (name, source) {
-  const fn = registry.get(name);
+export async function minify (minifierName, source) {
+  const fn = registry[minifierName].minify;
   if (!fn) {
-    throw new Error('Unknown minifier: ' + name);
+    throw new Error('Unknown minifier: ' + minifierName);
   }
   const output = await fn(source);
   return output.trim();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.10.0",
-        "@thejaredwilcurt/csslop": "^0.0.12",
-        "autoprefixer": "^10.5.2",
+        "@thejaredwilcurt/csslop": "^0.0.13",
+        "autoprefixer": "^10.5.4",
         "clean-css": "^5.3.3",
         "cross-env": "^10.1.0",
         "csskit": "^0.0.27",
@@ -19,17 +19,17 @@
         "cssnano-preset-advanced": "^8.0.2",
         "csso": "^5.0.5",
         "esbuild": "^0.28.1",
-        "eslint": "^10.6.0",
+        "eslint": "^10.7.0",
         "eslint-config-tjw-base": "^5.0.0",
         "eslint-config-tjw-import-x": "^1.0.1",
         "eslint-config-tjw-jsdoc": "^2.0.1",
         "eslint-plugin-import-x": "^4.17.1",
-        "eslint-plugin-jsdoc": "^63.0.12",
+        "eslint-plugin-jsdoc": "^63.0.13",
         "globals": "^17.7.0",
         "http-server": "^14.1.1",
         "lightningcss": "^1.30.0",
-        "marked": "^18.0.5",
-        "postcss": "^8.5.16",
+        "marked": "^18.0.6",
+        "postcss": "^8.5.19",
         "pretty-ms": "^9.3.0",
         "real-world-css-libraries": "^1.0.6",
         "sass": "^1.101.0",
@@ -1344,9 +1344,9 @@
       }
     },
     "node_modules/@thejaredwilcurt/csslop": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@thejaredwilcurt/csslop/-/csslop-0.0.12.tgz",
-      "integrity": "sha512-LI5mEnyIRtTbmaGSbVr7dChKFGtrQ7hVDQcvPnw9yuyY0TJPoWAuiSIbn7zjChThf9YcAQWT0UT3c8YAFtnsvw==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@thejaredwilcurt/csslop/-/csslop-0.0.13.tgz",
+      "integrity": "sha512-1LOTV2+zPKmfe5mw8kB+rh+Y/tfSZSaXvlLKnZokWOIf4yeQ5X2B8o+jzEMwjXu6xOTVh6y0G7gLbN2uuh7QLA==",
       "dev": true,
       "dependencies": {
         "@csstools/css-calc": "^3.2.1",
@@ -1850,9 +1850,9 @@
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
-      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "dev": true,
       "funding": [
         {
@@ -1870,8 +1870,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.4",
-        "caniuse-lite": "^1.0.30001799",
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -1963,10 +1963,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2019,9 +2019,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -2673,9 +2673,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.384",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
-      "integrity": "sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==",
+      "version": "1.5.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
       "dev": true,
       "license": "ISC"
     },
@@ -2791,9 +2791,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2945,9 +2945,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.0.12",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.12.tgz",
-      "integrity": "sha512-99VfBHyoLlF9n5w9wh+jLWDBzCgYd3tfw3M/aynAd+H2ylGHWLbde/GPTuo/5az3jMAN0fH7QzCYvEOY6u+Ypg==",
+      "version": "63.0.13",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.13.tgz",
+      "integrity": "sha512-ahG1kWA8jYNwaQJtzJlnF+v4Gb9w5r+WL98gp+L8qjLN9ErpL5sevGuemN+fCYsU3Np27F36KmDc8UPi1ml/dg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3880,9 +3880,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.6.tgz",
+      "integrity": "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4122,9 +4122,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4328,9 +4328,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@stylistic/eslint-plugin": "^5.10.0",
-    "@thejaredwilcurt/csslop": "^0.0.12",
-    "autoprefixer": "^10.5.2",
+    "@thejaredwilcurt/csslop": "^0.0.13",
+    "autoprefixer": "^10.5.4",
     "clean-css": "^5.3.3",
     "cross-env": "^10.1.0",
     "csskit": "^0.0.27",
@@ -23,17 +23,17 @@
     "cssnano-preset-advanced": "^8.0.2",
     "csso": "^5.0.5",
     "esbuild": "^0.28.1",
-    "eslint": "^10.6.0",
+    "eslint": "^10.7.0",
     "eslint-config-tjw-base": "^5.0.0",
     "eslint-config-tjw-import-x": "^1.0.1",
     "eslint-config-tjw-jsdoc": "^2.0.1",
     "eslint-plugin-import-x": "^4.17.1",
-    "eslint-plugin-jsdoc": "^63.0.12",
+    "eslint-plugin-jsdoc": "^63.0.13",
     "globals": "^17.7.0",
     "http-server": "^14.1.1",
     "lightningcss": "^1.30.0",
-    "marked": "^18.0.5",
-    "postcss": "^8.5.16",
+    "marked": "^18.0.6",
+    "postcss": "^8.5.19",
     "pretty-ms": "^9.3.0",
     "real-world-css-libraries": "^1.0.6",
     "sass": "^1.101.0",
@@ -47,7 +47,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "26.4.0"
+      "version": "26.5.0"
     },
     "packageManager": {
       "name": "npm",


### PR DESCRIPTION
* Groups all minifier data together to make it easier to maintain.
* Updates all references to "registry", including docs
* Closes #85. The point of that issue is to dynamically import minifiers. But if we are requiring additional metadata about them in the registry, I think that negates the original intent of # 85.
* Updates deps to latest
* Updates Node to latest