### PR TITLE
Site: Chart y-axis change

### DIFF
--- a/script.js
+++ b/script.js
@@ -64,6 +64,11 @@ window.addEventListener('hashchange', openHash);
   const reversed = [...data].reverse();
   const minifierNames = Object.keys(reversed[0].minifiers);
 
+  // Gets the largest test count and rounds up to nearest 100th
+  const max = Math.ceil(Math.max(...data.map((result) => {
+    return result.testCount;
+  })) / 100) * 100;
+
   const series = minifierNames.map((name) => ({
     name,
     data: reversed
@@ -74,7 +79,7 @@ window.addEventListener('hashchange', openHash);
         }
         return {
           x: new Date(entry.date).getTime(),
-          y: Math.round((m.pass / m.total) * 1000) / 10
+          y: m.pass
         };
       })
       .filter(Boolean)
@@ -104,9 +109,9 @@ window.addEventListener('hashchange', openHash);
       }
     },
     yaxis: {
-      title: { text: 'Pass Rate (%)' },
+      title: { text: 'Total Passing Tests' },
       min: 0,
-      max: 100,
+      max,
       decimalsInFloat: 1
     },
     tooltip: {


### PR DESCRIPTION
As new tests are added to the suite, it causes a downwards trend in the chart because it is based on percent of passing tests. So the more tests that are added, the worse it makes the minifiers look.

Trending downward:

<img width="1868" height="848" alt="downward" src="https://github.com/user-attachments/assets/11c00d4e-fed7-4d6e-bf0a-c0f885f3ff3d" />

This PR changes the chart to track the total number of passing tests. As new tests are added, sometimes the minifiers already pass them. Or as the minifiers improve and are updated, they pass more.

This chart tracks upward, showing both the passing of new tests, and minifier improvements.

Trending upward:

<img width="1868" height="848" alt="upward" src="https://github.com/user-attachments/assets/f62828c3-86b5-4481-90e2-0ec3c55548d6" />

On hover, it still shows the same information as before, `csslop: 100% (457/457 v0.0.14)`.