### PR TITLE
charset/0006 must be double quoted

### DIFF
--- a/tests/charset/0006/expected.css
+++ b/tests/charset/0006/expected.css
@@ -1,1 +1,1 @@
-@charset 'ISO-8859-15';.foo{color:red}.bar{color:tan}.baz{background:red}
+@charset "ISO-8859-15";.foo{color:red}.bar{color:tan}.baz{background:red}


### PR DESCRIPTION
CSS Syntax expects `@charset "` as the leading chars. 

https://drafts.csswg.org/css-syntax-3/#determine-the-fallback-encoding

Single quotes are invalid.