### PR TITLE
Extend charset tests

### DIFF
--- a/tests/charset/0002/expected.css
+++ b/tests/charset/0002/expected.css
@@ -1,1 +1,1 @@
-@charset "ISO-8859-1";a{color:red}
+@charset "gbk";a{color:red}

--- a/tests/charset/0002/source.css
+++ b/tests/charset/0002/source.css
@@ -1,5 +1,5 @@
-@charset "ISO-8859-1";
-@charset "ISO-8859-15";
+@charset "gbk";
+@charset "big5";
 a {
   color: red;
 }

--- a/tests/charset/0003/expected.css
+++ b/tests/charset/0003/expected.css
@@ -1,1 +1,1 @@
-@charset "iso-8859-15";a{color:red}
+@charset "gbk";a{color:red}

--- a/tests/charset/0005/expected.css
+++ b/tests/charset/0005/expected.css
@@ -1,1 +1,1 @@
-@charset "ISO-8859-1";.foo:before{content:"\e61d"}
+@charset "gbk";.foo:before{content:"\e61d"}

--- a/tests/charset/0005/source.css
+++ b/tests/charset/0005/source.css
@@ -1,4 +1,4 @@
-@charset "ISO-8859-1";
+@charset "gbk";
 .foo:before {
   content: "\e61d";
 }

--- a/tests/charset/0006/expected.css
+++ b/tests/charset/0006/expected.css
@@ -1,1 +1,1 @@
-@charset "ISO-8859-15";.foo{color:red}.bar{color:tan}.baz{background:red}
+@charset "gbk";.foo{color:red}.bar{color:tan}.baz{background:red}

--- a/tests/charset/0006/source.css
+++ b/tests/charset/0006/source.css
@@ -2,13 +2,13 @@
   color: red;
 }
 
-@charset 'ISO-8859-15';
+@charset "gbk";
 
 .bar {
   color: tan;
 }
 
-@charset 'ISO-8859-1';
+@charset "big5";
 
 .baz {
   background: red;

--- a/tests/charset/0007/README.md
+++ b/tests/charset/0007/README.md
@@ -1,0 +1,9 @@
+# A UTF-16 @charset label means UTF-8
+
+[Determining the fallback encoding] says that if the `@charset` label resolves
+to `utf-16be` or `utf-16le`, the encoding used is `utf-8`. The declaration bytes
+are ASCII, so the file cannot really be UTF-16. `@charset "utf-16be";` therefore
+means `@charset "utf-8";`, which is the default and can be dropped (see
+charset/0001).
+
+[Determining the fallback encoding]: https://drafts.csswg.org/css-syntax-3/#determine-the-fallback-encoding

--- a/tests/charset/0007/expected.css
+++ b/tests/charset/0007/expected.css
@@ -1,0 +1,1 @@
+a{color:red}

--- a/tests/charset/0007/source.css
+++ b/tests/charset/0007/source.css
@@ -1,0 +1,4 @@
+@charset "utf-16be";
+a {
+  color: red;
+}

--- a/tests/charset/0008/README.md
+++ b/tests/charset/0008/README.md
@@ -1,0 +1,11 @@
+# "utf-16" is a UTF-16LE label, so it also means UTF-8
+
+The Encoding Standard maps `utf-16`, `utf-16le`, `ucs-2`, `unicode`,
+`unicodefeff` and `iso-10646-ucs-2` to UTF-16LE, and `utf-16be` / `unicodefffe`
+to UTF-16BE. Every one of them becomes `utf-8` when
+[determining the fallback encoding], so the rule is redundant and removable.
+
+A minifier that string-matches only `utf-16be`/`utf-16le` keeps this rule and
+misses the optimisation.
+
+[determining the fallback encoding]: https://drafts.csswg.org/css-syntax-3/#determine-the-fallback-encoding

--- a/tests/charset/0008/expected.css
+++ b/tests/charset/0008/expected.css
@@ -1,0 +1,1 @@
+a{color:red}

--- a/tests/charset/0008/source.css
+++ b/tests/charset/0008/source.css
@@ -1,4 +1,4 @@
+@charset "utf-16";
 a {
   color: red;
 }
-@charset "gbk";

--- a/tests/charset/0009/README.md
+++ b/tests/charset/0009/README.md
@@ -1,0 +1,8 @@
+# Shorten the @charset label to its shortest alias
+
+Labels are looked up in the [Encoding Standard], which gives every encoding
+several aliases. `iso-8859-1`, `latin1`, `us-ascii`, `ascii`, `cp819` and `l1`
+all resolve to the same windows-1252 encoding, so `@charset "ISO-8859-1";`
+can be written `@charset "l1";`, saving 8 bytes.
+
+[Encoding Standard]: https://encoding.spec.whatwg.org/#names-and-labels

--- a/tests/charset/0009/expected.css
+++ b/tests/charset/0009/expected.css
@@ -1,0 +1,1 @@
+@charset "l1";a{color:red}

--- a/tests/charset/0009/source.css
+++ b/tests/charset/0009/source.css
@@ -1,0 +1,4 @@
+@charset "ISO-8859-1";
+a {
+  color: red;
+}

--- a/tests/charset/0009/validate.html
+++ b/tests/charset/0009/validate.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="../../../validate.css" />
+    <title>Validate: @charset label aliasing</title>
+    <link rel="stylesheet" href="data:text/css;base64,QGNoYXJzZXQgIklTTy04ODU5LTEiOwouYTo6YWZ0ZXJ7Y29udGVudDoi6SJ9Cg==" />
+    <link rel="stylesheet" href="data:text/css;base64,QGNoYXJzZXQgImwxIjsuYjo6YWZ0ZXJ7Y29udGVudDoi6SJ9Cg==" />
+  </head>
+  <body>
+    <div class="compare">
+      <div>
+        <h2>Source (unminified)</h2>
+        <div class="a">Decoded byte 0xE9: </div>
+      </div>
+      <div>
+        <h2>Expected (minified)</h2>
+        <div class="b">Decoded byte 0xE9: </div>
+      </div>
+    </div>
+
+    <p>
+      The two stylesheets above are loaded as bytes, each containing the same
+      single byte <code>0xE9</code> inside a <code>content</code> string. One
+      declares <code>@charset "ISO-8859-1"</code>, the other
+      <code>@charset "l1"</code>. Both must render <code>&eacute;</code>. A
+      <code>&#xFFFD;</code> means the label was not recognised and the file was
+      decoded as UTF-8 instead.
+    </p>
+  </body>
+</html>

--- a/tests/charset/0010/README.md
+++ b/tests/charset/0010/README.md
@@ -1,0 +1,9 @@
+# An unrecognised @charset label has no effect
+
+If the label does not match an [Encoding Standard] label the lookup fails and
+the stylesheet keeps the encoding it would have had anyway, so the rule is
+inert and removable. Gecko `DetermineNonBOMEncoding` only uses the label when
+`Encoding::ForLabel` returns non-null; WebKit/Blink `SetEncoding` returns early
+when `!encoding.IsValid()`.
+
+[Encoding Standard]: https://encoding.spec.whatwg.org/#names-and-labels

--- a/tests/charset/0010/expected.css
+++ b/tests/charset/0010/expected.css
@@ -1,0 +1,1 @@
+a{color:red}

--- a/tests/charset/0010/source.css
+++ b/tests/charset/0010/source.css
@@ -1,0 +1,4 @@
+@charset "not-a-charset";
+a {
+  color: red;
+}


### PR DESCRIPTION
This fixes https://github.com/keithamus/css-minify-tests/issues/181 by adding a test for charsets with `utf-16le`/``utf-16be` and letting them resolve to `utf-8`. 

This also got me curious, so I looked up the WebKit/Gecko/Chromium codebases and found that they all use lookup tables from the [Encoding spec](https://encoding.spec.whatwg.org/#names-and-labels). This means `"iso-8859-2"` can successfully be minified to `"l2"` as they're both aliases for the same encoding. I've added a `validate.html` to prove this out. This, unfortunately, meant re-doing most of the charset tests as they use `"ISO-8859-1"` - so they need changing to `"gbk"` or `"big5"` which are already their shortest forms.