### PR TITLE
Add even more charset tests

### DIFF
--- a/tests/charset/0011/README.md
+++ b/tests/charset/0011/README.md
@@ -1,0 +1,5 @@
+# An uppercased @charset is not an encoding declaration
+
+CSS at-keywords are ASCII case-insensitive, but the @charset rule, and its value
+are not: engines compare raw bytes against `@charset "`. So `@CHARSET "gbk";`
+declares nothing and the parser drops the at-rule; it can be removed.

--- a/tests/charset/0011/expected.css
+++ b/tests/charset/0011/expected.css
@@ -1,0 +1,1 @@
+a{color:red}

--- a/tests/charset/0011/source.css
+++ b/tests/charset/0011/source.css
@@ -1,0 +1,4 @@
+@CHARSET "gbk";
+a {
+  color: red;
+}

--- a/tests/charset/0012/README.md
+++ b/tests/charset/0012/README.md
@@ -1,0 +1,10 @@
+# Never resolve escapes inside a @charset label
+
+Engines read `@charset` rules as raw bytes, not CSS strings, therefore escaping
+isn't taken into account. Everything between `@charset "` and `";` is the label.
+The literal bytes of `\67 bk` might resolve in CSS syntax as "gbk" - a valid
+encoding label, but the pre-escaped label not an Encoding Standard label, so
+the rule is inert and removable.
+
+A minifier that unescapes strings would emit `@charset "gbk";` and change how
+the browser decodes the whole file. This is incorrect.

--- a/tests/charset/0012/expected.css
+++ b/tests/charset/0012/expected.css
@@ -1,0 +1,1 @@
+a{color:red}

--- a/tests/charset/0012/source.css
+++ b/tests/charset/0012/source.css
@@ -1,0 +1,4 @@
+@charset "\67 bk";
+a {
+  color: red;
+}

--- a/tests/charset/0013/README.md
+++ b/tests/charset/0013/README.md
@@ -1,0 +1,9 @@
+# A single-quoted @charset is not an encoding declaration
+
+`@charset` must use single quotes, as the byte sequence - not "tokenized" syntax
+is detected. `@charset 'gbk';` is therefore inert, and will be discarded in
+engines. Minifiers can therefore safely remove this.
+
+Normalising the quotes instead - which minifiers do to ordinary strings - turns
+a rule the browser ignored into a live encoding declaration. This is incorrect
+and may cause bugs.

--- a/tests/charset/0013/expected.css
+++ b/tests/charset/0013/expected.css
@@ -1,0 +1,1 @@
+a{color:red}

--- a/tests/charset/0013/source.css
+++ b/tests/charset/0013/source.css
@@ -1,0 +1,4 @@
+@charset 'gbk';
+a {
+  color: red;
+}


### PR DESCRIPTION
Looking through our Charset tests, the spec, and browser's source, I found a couple more issues. All to do with exact byte matching (as opposed to token matching):

- Charsets must use single quotes, so `@charset '` is disregarded as an invalid at rule.
- Charset values must not escape characters, so `@charset "\67 bk"` is invalid. If a minifier converts that to `@charset "gbk"` that suddenly becomes valid, so a correctness bug.
- It's case sensitive, so `@CHARSET ` is invalid, disregarded as an invalid rule.