### PR TITLE
Extend shorthands/0059 with more examples

### DIFF
--- a/tests/shorthands/0059/expected.css
+++ b/tests/shorthands/0059/expected.css
@@ -1,1 +1,1 @@
-a{padding:10px 20px 10px 10px}b{padding:10000px;padding-right:200px}
+a{padding:10px 20px 10px 10px}b{padding:10000px;padding-right:200px}c{padding:20px 10px 10px}d{padding:1px 4px 3px}e{padding:inherit;padding-right:20px}f{padding:var(--padding);padding-right:20px}g{padding:10px;padding-right:20px!important}

--- a/tests/shorthands/0059/source.css
+++ b/tests/shorthands/0059/source.css
@@ -7,3 +7,28 @@ b {
   padding: 10000px;
   padding-right: 200px;
 }
+
+c {
+  padding: 10px;
+  padding-top: 20px;
+}
+
+d {
+  padding: 1px 2px 3px 4px;
+  padding-right: 4px;
+}
+
+e {
+  padding: inherit;
+  padding-right: 20px;
+}
+
+f {
+  padding: var(--padding);
+  padding-right: 20px;
+}
+
+g {
+  padding: 10px;
+  padding-right: 20px !important;
+}


### PR DESCRIPTION
shorthands/0059 felt a little slim, this adds a few more interesting examples:

 - a three value padding can be shorter than a single value + override.
 - overrides can be absorbed into the shorthand.
 - `inherit` is dangerous to try to combine.
 - expanding to a three-value syntax may be longer, especially when using `var()`
 - `!important` is dangerous to try to combine.