### PR TITLE
Remove whitespace in shorthand tests

### DIFF
--- a/tests/shorthands-unsafe/0007/expected.css
+++ b/tests/shorthands-unsafe/0007/expected.css
@@ -1,1 +1,1 @@
-.a{border-image:url(border.png) 30 round}.b{border-width:1px;border-style:solid;border-color:red}
+.a{border-image:url(border.png)30 round}.b{border-width:1px;border-style:solid;border-color:red}

--- a/tests/shorthands-unsafe/0010/expected.css
+++ b/tests/shorthands-unsafe/0010/expected.css
@@ -1,1 +1,1 @@
-.a{mask-border:url(mask.png) 25/10px round}.b{mask-image:url(mask.svg);mask-position:center;mask-size:cover;mask-repeat:no-repeat;mask-origin:border-box;mask-clip:border-box;mask-composite:add;mask-mode:alpha}
+.a{mask-border:url(mask.png)25/10px round}.b{mask-image:url(mask.svg);mask-position:center;mask-size:cover;mask-repeat:no-repeat;mask-origin:border-box;mask-clip:border-box;mask-composite:add;mask-mode:alpha}

--- a/tests/shorthands/0020/expected.css
+++ b/tests/shorthands/0020/expected.css
@@ -1,1 +1,1 @@
-a{border:1px solid red;border-image:url(border.png) 30 round}
+a{border:1px solid red;border-image:url(border.png)30 round}

--- a/tests/shorthands/0021/source.css
+++ b/tests/shorthands/0021/source.css
@@ -2,5 +2,5 @@ a {
   border-width: 1px;
   border-style: solid;
   border-color: red;
-  border-image: url(border.png) 30 round;
+  border-image: url(border.png)30 round;
 }

--- a/tests/shorthands/0022/source.css
+++ b/tests/shorthands/0022/source.css
@@ -1,4 +1,4 @@
 a {
-  border-image: url(border.png) 30 round;
+  border-image: url(border.png)30 round;
   border: 1px solid red;
 }

--- a/tests/shorthands/0025/expected.css
+++ b/tests/shorthands/0025/expected.css
@@ -1,1 +1,1 @@
-a{font:italic 700 16px/1.5 Arial,sans-serif;font-feature-settings:"smcp" 1}
+a{font:italic 700 16px/1.5 Arial,sans-serif;font-feature-settings:"smcp"1}

--- a/tests/shorthands/0028/expected.css
+++ b/tests/shorthands/0028/expected.css
@@ -1,1 +1,1 @@
-a{mask:linear-gradient(#000,#0000) no-repeat/cover;mask-border:url(mask.png) 25/10px round}
+a{mask:linear-gradient(#000,#0000)no-repeat/cover;mask-border:url(mask.png)25/10px round}

--- a/tests/shorthands/0029/expected.css
+++ b/tests/shorthands/0029/expected.css
@@ -1,1 +1,1 @@
-a{mask:linear-gradient(#000,#0000) no-repeat;mask-border:url(mask.png) 25 round}
+a{mask:linear-gradient(#000,#0000)no-repeat;mask-border:url(mask.png)25 round}


### PR DESCRIPTION
csskit's shorthand reducer is nearly there, but we're failing some tests due to (properly) eliding whitespace where tokens can become ambiguous, meaning we produce shorter results than the css-minify-test corpus claims is possible. 

This changes the tests to match the outputs of csskit - reducing whitespace after parens and quotes, lining up with similar tests.