### PR TITLE
Fix build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  actions: read
+  contents: read
   id-token: write
 
 concurrency:
@@ -25,6 +29,17 @@ jobs:
       - run: npm -v
       - run: npm i
       - run: npm run lint
+      - name: Download results history
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
+        with:
+          name: results-history
+          workflow: build.yml
+          workflow_conclusion: success
+          branch: main
+          search_artifacts: true
+          if_no_artifact_found: warn
+          path: data
+
       - run: npm t
 
       - name: Upload PR results
@@ -34,27 +49,27 @@ jobs:
           name: pr-results
           path: data/results.json
 
-      - name: Commit results history
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/results-history.json
-          git diff --cached --quiet || (git commit -m "Update results history" && git push)
-
       - name: Prepare pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         run: mkdir -p _site && cp index.html style.css script.js _site/ && cp -r minified/ _site/minified/
 
       - name: Setup Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload HTML report
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
+
+      - name: Upload results history artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: results-history
+          path: data/results-history.json
+          retention-days: 90
 
   pr-baseline:
     if: github.event_name == 'pull_request'
@@ -77,7 +92,7 @@ jobs:
           path: data/results.json
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
Fixes https://github.com/keithamus/css-minify-tests/issues/198 by using GitHub's artefact storage to store the results-history.json file. This means we no longer commit & push to main, instead relying on GitHub to store the JSON file. GitHub has a 90 day retention window, so I've also added a cron schedule to ensure the site is built at least every Monday, ensuring freshness.

This is mostly copied from csskit https://github.com/csskit/csskit/blob/main/.github/workflows/benchmark-tracking.yml#L20-L41, https://github.com/csskit/csskit/blob/main/.github/workflows/pages.yml#L32-L41 which does a similar thing with benchmark data, and works well.