### PR TITLE
Fix pr-comment

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -58,7 +58,7 @@ jobs:
 
 
       - name: Generate comment
-        run: node scripts/pr-comment.js baseline/data/results.json pr/data/results.json > comment.md
+        run: node scripts/pr-comment.js baseline/results.json pr/results.json > comment.md
 
       - name: Post or update PR comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
When we changes from `results.json` to `data/results.json` in https://github.com/keithamus/css-minify-tests/pull/79 this workflow wasn't updated so it definitely fails. This should get it working (or not, as it wasn't really working before that, but it'll help us zero in on a failure at least).