### PR TITLE
pr-comment: Get PR number from GH API

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           name: baseline-results
           run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           path: baseline
 
       - name: Download PR results
@@ -44,17 +43,31 @@ jobs:
         with:
           name: pr-results
           run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           path: pr
 
       - name: Resolve PR number
         id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR: ${{ inputs.pr_number }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            number="$INPUT_PR"
           else
-            echo "number=${{ github.event.workflow_run.pull_requests[0].number }}" >> $GITHUB_OUTPUT
+            number=$(gh api \
+              "repos/${{ github.repository }}/pulls?state=all&head=$HEAD_REPO:$HEAD_BRANCH" \
+              --jq '(map(select(.state == "open")) + .) | .[0].number // empty') || number=""
           fi
+          case "$number" in
+            '' | *[!0-9]*)
+              echo "::error::No PR found for $HEAD_REPO:$HEAD_BRANCH"
+              exit 1
+              ;;
+          esac
+          echo "number=$number" >> "$GITHUB_OUTPUT"
 
 
       - name: Generate comment


### PR DESCRIPTION
This attempts to fix the pr-comment workflow for forks, by using `gh` cli to get the PR number for the ref, instead of relying on GitHub's CI inputs, as they're wrong for forks.