### PR TITLE
Add shorthands-unsafe 0011

### DIFF
--- a/tests/shorthands-unsafe/0011/README.md
+++ b/tests/shorthands-unsafe/0011/README.md
@@ -1,0 +1,7 @@
+# Repeated var() in a shorthand value cannot be deduplicated
+
+`margin: 1px 1px` reduces to `margin: 1px`, but the same reduction across two
+`var()` references is unsafe because the variable could contain an unknown
+number of components, for example if `--a` expands to three or four values the
+doubled form has six or eight components and is invalid at computed-value time,
+while the reduced form remains valid.

--- a/tests/shorthands-unsafe/0011/expected.css
+++ b/tests/shorthands-unsafe/0011/expected.css
@@ -1,0 +1,1 @@
+a{margin:var(--a)var(--a)}

--- a/tests/shorthands-unsafe/0011/source.css
+++ b/tests/shorthands-unsafe/0011/source.css
@@ -1,0 +1,3 @@
+a {
+  margin: var(--a) var(--a);
+}


### PR DESCRIPTION
Testing csskit's reducer implementations, I spotted that we were accidentally doing this, so I wrote a test.