### PR TITLE
Fixup shorthands/0054

### DIFF
--- a/tests/shorthands/0054/README.md
+++ b/tests/shorthands/0054/README.md
@@ -7,5 +7,6 @@ be represented by `border` effectively, so treating it like a shorthand with
 sides would result in an invalid declaration such as
 `border: 1px solid red 2px dotted blue`.
 
-They can, however, be reduced to a shorter value by using the `border-color`,
-`border-style`, `border-width` syntax, which will result in overall smaller CSS.
+They can, however, be reduced to a shorter value by using the `border-width`,
+`border-style`, `border-color` syntax, which will result in overall smaller CSS.
+The parts are written in the order `border` itself takes them.

--- a/tests/shorthands/0054/expected.css
+++ b/tests/shorthands/0054/expected.css
@@ -1,1 +1,1 @@
-a{border-color:red blue;border-style:solid dotted;border-width:1px 2px}
+a{border-width:1px 2px;border-style:solid dotted;border-color:red blue}


### PR DESCRIPTION
`shorthands/0054` and `shorthands-unsafe/0007` contradict each-other on ordering of the properties. 

This change fixes `shorthands/0054` to use the other tests order - which is grammar order.