### PR TITLE
add alternates files, for multiple valid representations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ tests/
     <NNNN>/
       source.css       # Unminified input (formatted, 2-space indent)
       expected.css     # Canonical minified output (single line + newline)
+      expected.alt.css # Optional. Another equally acceptable output. Any
+                       # `expected.<name>.css` file is accepted as a pass.
       README.md        # 2-4 line description of the transformation
       validate.html    # For difficult to reason about tests, this can provide
                        # an test example to run in browsers, showcasing this.
@@ -101,6 +103,12 @@ colons). Some tips:
 
 The shortest correct representation that is semantically identical to the
 source. Must be a **single line terminated by a newline**.
+
+If more than one output is equally short and equally correct (for example the
+longhands of a shorthand could be written in any order), add each other
+acceptable output as `expected.<name>.css`, such as `expected.alt.css`. A
+minifier passes the test when its output matches `expected.css` or any
+`expected.*.css` files.
 
 
 ### 7. Write `README.md`

--- a/lib/createWebsite/makeTestTables.js
+++ b/lib/createWebsite/makeTestTables.js
@@ -12,7 +12,8 @@ import {
 } from '../constants.js';
 import {
   formatMs,
-  html
+  html,
+  matchesExpected
 } from '../helpers.js';
 import {
   getMinifierTitle,
@@ -89,7 +90,6 @@ async function detailRow (test) {
     const duration = test.durations[minifierName];
     durations += html`<div>${formatMs(duration)}</div>`;
 
-    const expected = test.expected;
     const error = test.errors[minifierName];
     const actual = test.actual[minifierName];
     if (error) {
@@ -103,7 +103,7 @@ async function detailRow (test) {
         ${errorMarkup}
       </div>`;
     } else if (actual !== null) {
-      const match = actual === expected;
+      const match = matchesExpected(test, actual);
       const actualMarkup = await codeToHtml(actual, shikiOptions);
       const icon = match ? 'pass-icon' : 'fail-icon';
       const mark = match ? CHECKMARK : CROSS_MARK;
@@ -137,6 +137,16 @@ async function detailRow (test) {
 
   const sourceMarkup = await codeToHtml(test.source, shikiOptions);
   const expectedMarkup = await codeToHtml(test.expected, shikiOptions);
+  let alternatesMarkup = '';
+  for (const alternate of (test.alternates || [])) {
+    alternatesMarkup += await codeToHtml(alternate, shikiOptions);
+  }
+  if (alternatesMarkup) {
+    alternatesMarkup = html`<div>
+      <h4>Also accepted</h4>
+      ${alternatesMarkup}
+    </div>`;
+  }
   const colCount = (1 + minifiers.length);
   const customProperties = [
     '--colCount: ' + colCount,
@@ -173,6 +183,7 @@ async function detailRow (test) {
           <h4>Expected</h4>
           ${expectedMarkup}
         </div>
+        ${alternatesMarkup}
         ${validate}
         <div>
           <h4>Outputs</h4>
@@ -198,7 +209,6 @@ async function detailRow (test) {
  */
 function makeTestOverviewRow (test) {
   const {
-    expected,
     groupName,
     testNumber
   } = test;
@@ -222,7 +232,7 @@ function makeTestOverviewRow (test) {
     let mark = CROSS_MARK;
     let title;
 
-    if (actual === expected) {
+    if (matchesExpected(test, actual)) {
       cellClass = 'pass';
       icon = 'pass-icon';
       mark = CHECKMARK;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -35,6 +35,25 @@ export const formatMs = function (duration) {
 };
 
 /**
+ * Tells if a minifier output is one of the acceptable outputs for a test.
+ * A test passes on the "expected.css" contents, or on the contents of any
+ * "expected.*.css" file.
+ *
+ * @param  {object}  test    The test data, with "expected" and "alternates"
+ * @param  {string}  actual  The output of a minifier
+ * @return {boolean}         true if the output is acceptable
+ */
+export const matchesExpected = function (test, actual) {
+  if (typeof(actual) !== 'string') {
+    return false;
+  }
+  return (
+    actual === test.expected ||
+    (test.alternates || []).includes(actual)
+  );
+};
+
+/**
  * Used to apply better syntax highlighting for strings of markup.
  *
  * @param  {string[]} strings  Static string content

--- a/lib/loaders/loadAllTests.js
+++ b/lib/loaders/loadAllTests.js
@@ -42,16 +42,17 @@ const inlineCss = function (testFile, fileContents) {
 };
 
 /**
- * @typedef  {object} TESTDATA
- * @property {string} groupName   Category name test type (anchor, colors, etc)
- * @property {string} testNumber  Which test in the category (0001, 0002, etc)
- * @property {string} source      The contents of the "source.css" file
- * @property {string} expected    The contents of the "expected.css" file
- * @property {string} readme      The contents of the "README.md" file
- * @property {string} [validate]  The contents of the "validate.html" file
- * @property {object} durations   An empty object to store minifier run times
- * @property {object} actual      An empty object to store the minifier outputs
- * @property {object} errors      An empty object to store minifier errors
+ * @typedef  {object}   TESTDATA
+ * @property {string}   groupName   Category name test type (anchor, colors, etc)
+ * @property {string}   testNumber  Which test in the category (0001, 0002, etc)
+ * @property {string}   source      The contents of the "source.css" file
+ * @property {string}   expected    The contents of the "expected.css" file
+ * @property {string[]} alternates  Contents of any "expected.*.css" files
+ * @property {string}   readme      The contents of the "README.md" file
+ * @property {string}   [validate]  The contents of the "validate.html" file
+ * @property {object}   durations   An empty object to store minifier run times
+ * @property {object}   actual      An empty object to store the minifier outputs
+ * @property {object}   errors      An empty object to store minifier errors
  */
 
 /**
@@ -85,8 +86,9 @@ export const loadAllTests = function () {
       // '/tests/anchor/0001'
       const numberedTestFolder = join(testGroupFolder, numberedTest);
 
-      // ['expected.css', 'README.md', ...]
+      // ['expected.css', 'expected.alt.css', 'README.md', ...]
       const testFiles = readdirSync(numberedTestFolder).sort(customSort);
+      const alternates = [];
       for (const testFile of testFiles) {
         // 'tests/anchor/0001/expected.css'
         const fullPath = join(numberedTestFolder, testFile);
@@ -94,10 +96,23 @@ export const loadAllTests = function () {
         let fileContents = String(readFileSync(fullPath)).trim();
         fileContents = inlineCss(testFile, fileContents);
 
+        const lowerName = testFile.toLowerCase();
+        const isAlternate = (
+          lowerName !== 'expected.css' &&
+          lowerName.startsWith('expected.') &&
+          lowerName.endsWith('.css')
+        );
+        // 'expected.alt.css' holds an equally acceptable output
+        if (isAlternate) {
+          alternates.push(fileContents);
+          continue;
+        }
+
         // 'README.md' => 'readme'
-        const name = testFile.toLowerCase().split('.')[0];
+        const name = lowerName.split('.')[0];
         testData[name] = fileContents;
       }
+      testData.alternates = alternates;
 
       // Storage for minifier test results
       testData.durations = {};

--- a/lib/reporters/allTests.js
+++ b/lib/reporters/allTests.js
@@ -6,6 +6,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import { matchesExpected } from '../helpers.js';
 import { prependHistory } from '../history.js';
 import { minifiers } from '../loaders/loadAllMinifiers.js';
 import { getVersions } from '../loaders/loadVersions.js';
@@ -79,10 +80,7 @@ export const totalsFromAllTests = function (allTests) {
         (results.totals[minifierName].durations || 0) +
         test.durations[minifierName]
       );
-      if (
-        typeof(test.actual[minifierName]) === 'string' &&
-        test.actual[minifierName] === test.expected
-      ) {
+      if (matchesExpected(test, test.actual[minifierName])) {
         results.totals[minifierName].pass++;
         results.groups[test.groupName][minifierName].pass++;
       }
@@ -190,10 +188,9 @@ export const reportTestResults = async function (allTests, results) {
   for (const test of allTests) {
     const fullTestName = test.groupName + '/' + test.testNumber;
     resultsJson[fullTestName] = {};
-    const expected = test.expected;
     for (const minifierName in test.actual) {
       const actual = test.actual[minifierName];
-      resultsJson[fullTestName][minifierName] = expected === actual;
+      resultsJson[fullTestName][minifierName] = matchesExpected(test, actual);
     }
   }
 

--- a/lib/runners/allTests.js
+++ b/lib/runners/allTests.js
@@ -8,16 +8,17 @@ import { loadAllTests } from '../loaders/loadAllTests.js';
 import { minify } from '../minify.js';
 
 /**
- * @typedef  {object} RANTEST
- * @property {string} groupName   Category name test type (anchor, colors, etc)
- * @property {string} testNumber  Which test in the category (0001, 0002, etc)
- * @property {string} source      The contents of the "source.css" file
- * @property {string} expected    The contents of the "expected.css" file
- * @property {string} readme      The contents of the "README.md" file
- * @property {string} [validate]  The contents of the "validate.html" file
- * @property {object} durations   An object with minifier names as key and run times as value
- * @property {object} actual      An object with minifier names as key and minified outputs as value
- * @property {object} errors      An object with minifier names as key and errors as value
+ * @typedef  {object}   RANTEST
+ * @property {string}   groupName   Category name test type (anchor, colors, etc)
+ * @property {string}   testNumber  Which test in the category (0001, 0002, etc)
+ * @property {string}   source      The contents of the "source.css" file
+ * @property {string}   expected    The contents of the "expected.css" file
+ * @property {string[]} alternates  Contents of any "expected.*.css" files
+ * @property {string}   readme      The contents of the "README.md" file
+ * @property {string}   [validate]  The contents of the "validate.html" file
+ * @property {object}   durations   An object with minifier names as key and run times as value
+ * @property {object}   actual      An object with minifier names as key and minified outputs as value
+ * @property {object}   errors      An object with minifier names as key and errors as value
  */
 
 /**

--- a/scripts/pr-comment.js
+++ b/scripts/pr-comment.js
@@ -22,6 +22,25 @@ const readTestFile = async (testPath, name) => {
   }
 };
 
+const readAlternates = async (testPath) => {
+  let names;
+  try {
+    names = await fs.readdir(path.join('tests', testPath));
+  } catch {
+    return [];
+  }
+  names = names
+    .filter((name) => {
+      return (
+        name !== 'expected.css' &&
+        name.startsWith('expected.') &&
+        name.endsWith('.css')
+      );
+    })
+    .sort();
+  return Promise.all(names.map((name) => readTestFile(testPath, name)));
+};
+
 const playgroundParam = (css) =>
   zlib.deflateSync(Buffer.from(css, 'utf-8'), { level: 9 }).toString('base64');
 
@@ -33,7 +52,8 @@ const loadTestCss = (testPath) => {
       testPath,
       Promise.all([
         readTestFile(testPath, 'source.css'),
-        readTestFile(testPath, 'expected.css')
+        readTestFile(testPath, 'expected.css'),
+        readAlternates(testPath)
       ])
     );
   }
@@ -55,7 +75,7 @@ const playgroundUrl = async (testPath) => {
 const testDetails = async (testPaths) => {
   const blocks = [];
   for (const testPath of testPaths) {
-    const [source, expected] = await loadTestCss(testPath);
+    const [source, expected, alternates] = await loadTestCss(testPath);
     if (!source) {
       continue;
     }
@@ -74,10 +94,19 @@ const testDetails = async (testPaths) => {
       '',
       '```css',
       expected,
-      '```',
-      '',
-      '</details>'
+      '```'
     );
+    for (const alternate of alternates) {
+      blocks.push(
+        '',
+        '**Also accepted**',
+        '',
+        '```css',
+        alternate,
+        '```'
+      );
+    }
+    blocks.push('', '</details>');
   }
   return blocks;
 };

--- a/tests/shorthands-unsafe/0007/expected.alt.css
+++ b/tests/shorthands-unsafe/0007/expected.alt.css
@@ -1,0 +1,1 @@
+.a{border-image:url(border.png)30 round}.b{border-color:red;border-style:solid;border-width:1px}

--- a/tests/shorthands/0054/README.md
+++ b/tests/shorthands/0054/README.md
@@ -9,4 +9,6 @@ sides would result in an invalid declaration such as
 
 They can, however, be reduced to a shorter value by using the `border-width`,
 `border-style`, `border-color` syntax, which will result in overall smaller CSS.
-The parts are written in the order `border` itself takes them.
+While any order creates valid CSS, the parts should be written in grammar order
+(the order `border` itself takes them) or alphabetical, to improve the chance of
+good gzip compressibility.

--- a/tests/shorthands/0054/expected.alt.css
+++ b/tests/shorthands/0054/expected.alt.css
@@ -1,0 +1,1 @@
+a{border-color:red blue;border-style:solid dotted;border-width:1px 2px}


### PR DESCRIPTION
https://github.com/keithamus/css-minify-tests/pull/215 pointed out a contradiction in `shorthands/0054` and `shorthands-unsafe/0007` which contradicted each-other on ordering of the properties. The PR changed both to be aligned to grammar order, which feels "canonically correct" but cssnano re-orders properties alphabetically, and so it feels unfair to have cssnano lose a point due to this decision, considering both are equally valid.

This change introduces a concept of "alternate expectations" which allow us to author multiple `expected.*.css` files, and if a minifier matches _any_ file then it is considered a pass.

We've talked about this before (most recently and somewhat similarly related would be
https://github.com/keithamus/css-minify-tests/pull/146#discussion_r3622506272).

This feels like the "maximally minimal" change to enable this.