### PR TITLE
Add edge cases around merging values with differing equality

### DIFF
--- a/tests/merging/0011/README.md
+++ b/tests/merging/0011/README.md
@@ -1,0 +1,5 @@
+# Merging rules is unsafe when custom idents differ
+
+`animation-name: pulse` and `animation-name: shake` name different keyframes, so
+the rules cannot share a selector list. Minifiers need to check the actual value
+to ensure they don't merge different values.

--- a/tests/merging/0011/expected.css
+++ b/tests/merging/0011/expected.css
@@ -1,0 +1,1 @@
+a{animation-name:pulse}b{animation-name:shake}

--- a/tests/merging/0011/source.css
+++ b/tests/merging/0011/source.css
@@ -1,0 +1,7 @@
+a {
+  animation-name: pulse;
+}
+
+b {
+  animation-name: shake;
+}

--- a/tests/merging/0012/README.md
+++ b/tests/merging/0012/README.md
@@ -1,0 +1,5 @@
+# Merging rules is unsafe when strings differ
+
+`content: "i"` and `content: "j"` insert different text, so the rules cannot
+share a selector list. A minifier needs to check the actual value and cannot
+merge these rules.

--- a/tests/merging/0012/expected.css
+++ b/tests/merging/0012/expected.css
@@ -1,0 +1,1 @@
+a{content:"i"}b{content:"j"}

--- a/tests/merging/0012/source.css
+++ b/tests/merging/0012/source.css
@@ -1,0 +1,7 @@
+a {
+  content: "i";
+}
+
+b {
+  content: "j";
+}

--- a/tests/merging/0013/README.md
+++ b/tests/merging/0013/README.md
@@ -1,0 +1,5 @@
+# Merging rules is unsafe when function arguments differ
+
+`scale(2,3)` and `scale(3,2)` scale the two axes by swapped factors, so the
+rules cannot be merged. A minifier might compare the arguments regardless of
+order, and treat these two transforms as the same transform.

--- a/tests/merging/0013/expected.css
+++ b/tests/merging/0013/expected.css
@@ -1,0 +1,1 @@
+a{transform:scale(2,3)}b{transform:scale(3,2)}

--- a/tests/merging/0013/source.css
+++ b/tests/merging/0013/source.css
@@ -1,0 +1,7 @@
+a {
+  transform: scale(2, 3);
+}
+
+b {
+  transform: scale(3, 2);
+}

--- a/tests/merging/0014/README.md
+++ b/tests/merging/0014/README.md
@@ -1,0 +1,4 @@
+# Merging rules is unsafe when the value after a slash differs
+
+The `mask` shorthand takes the mask size after a slash, so `center/cover` and
+`center/contain` scale the mask differently and the rules cannot be merged.

--- a/tests/merging/0014/expected.css
+++ b/tests/merging/0014/expected.css
@@ -1,0 +1,1 @@
+a{mask:center/cover}b{mask:center/contain}

--- a/tests/merging/0014/source.css
+++ b/tests/merging/0014/source.css
@@ -1,0 +1,7 @@
+a {
+  mask: center / cover;
+}
+
+b {
+  mask: center / contain;
+}


### PR DESCRIPTION
I was looking at implementing rule merging and realised csskit has some pretty bad bugs around semantic equality, so thought I'd write up some tests for these.