### PR TITLE
Fix invalid expected mask value in shorthands/0028

### DIFF
--- a/tests/shorthands/0028/expected.css
+++ b/tests/shorthands/0028/expected.css
@@ -1,1 +1,1 @@
-a{mask:linear-gradient(#000,#0000)no-repeat/cover;mask-border:url(mask.png)25/10px round}
+a{mask:linear-gradient(#000,#0000)0 0/cover no-repeat;mask-border:url(mask.png)25/10px round}


### PR DESCRIPTION
The `/cover` syntax needs a preceding position. The syntax for `mask-layer` is as follows:

```
<mask-layer> = <mask-reference> || <position> [ / <bg-size> ]? || ...
 ```

This states that position is required, and the trailing `<bg-size>` is optional
but must also use the `/` to disambiguate. By omitting the `<position>` we
create an expectation which is invalid syntax.

Luckily, `mask` shorthand would reset any `<position>`, therefore `0 0` can be
used to set the position to its initial value.