### PR TITLE
use unminifiable colour for shorthand test

### DIFF
--- a/tests/shorthands/0035/expected.css
+++ b/tests/shorthands/0035/expected.css
@@ -1,1 +1,1 @@
-@property --bw{syntax:"<length>";inherits:false;initial-value:0px}@property --bs{syntax:"<custom-ident>";inherits:false;initial-value:none}@property --bc{syntax:"<color>";inherits:false;initial-value:#000}a{border:var(--bw) var(--bs) var(--bc)}
+@property --bw{syntax:"<length>";inherits:false;initial-value:0px}@property --bs{syntax:"<custom-ident>";inherits:false;initial-value:none}@property --bc{syntax:"<color>";inherits:false;initial-value:red}a{border:var(--bw) var(--bs) var(--bc)}

--- a/tests/shorthands/0035/source.css
+++ b/tests/shorthands/0035/source.css
@@ -11,7 +11,7 @@
 @property --bc {
   syntax: "<color>";
   inherits: false;
-  initial-value: black;
+  initial-value: red;
 }
 a {
   border-width: var(--bw);


### PR DESCRIPTION
This test used "black" which minifies to "#000" - however that tests colour minification, alongside shorthand merging, which makes this two tests instead of one.

Per our contributing guidelines we should try to aim for one test and use filler declarations/values which already are their most compact form.