### PR TITLE
 shrink even more whitespace in shorthand tests 

### DIFF
--- a/tests/shorthands/0023/expected.css
+++ b/tests/shorthands/0023/expected.css
@@ -1,1 +1,1 @@
-a{border:4px solid #0000;border-image:url(border.png)30 round}
+a{border:4px solid#0000;border-image:url(border.png)30 round}


### PR DESCRIPTION
It's possible to shrink this line even further by removing whitespace between keyword and hex colour.