### PR TITLE
Copy reminified folder during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Prepare pages artifact
         if: github.event_name != 'pull_request'
-        run: mkdir -p _site && cp index.html style.css script.js _site/ && cp -r minified/ _site/minified/
+        run: mkdir -p _site && cp index.html style.css script.js _site/ && cp -r minified/ _site/minified/ && cp -r reminified/ _site/reminified/
 
       - name: Setup Pages
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
This will let you click on the idempotency button on the real world tests to open up the re-minified results.

I'm just going to merge this to see if it works.

yep worked